### PR TITLE
Simple Python import fix

### DIFF
--- a/src/python/interaction/__init__.py
+++ b/src/python/interaction/__init__.py
@@ -21,4 +21,6 @@ limitations under the License.
 from .thc import make_thc_coulomb
 from .cholesky import make_chol_coulomb
 
+from . import pyscf_interface
+
 __all__ = ["make_thc_coulomb", "make_chol_coulomb"]

--- a/src/python/mean_field/__init__.py
+++ b/src/python/mean_field/__init__.py
@@ -20,4 +20,6 @@ limitations under the License.
 
 from .mf import make_mf
 
+from . import pyscf_interface
+
 __all__ = ["make_mf"]


### PR DESCRIPTION
This fix allows one to import `pyscf_interface` as module, allowing to run the code below:
```
import coqui
...
coqui.interaction.pyscf_interface.mol_gdf_dump_to_h5(mydf, outdir="gdf_coulomb")
coqui.mean_field.pyscf_interface.converter.mol_dump_to_h5(mf, becke_grid_level=9, mo=False, outdir='./', prefix='pyscf')
```