### PR TITLE
Dump ISDF results to hdf5 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -467,7 +467,7 @@ if(COQUI_PYTHON_SUPPORT)
   FetchContent_Declare(
     c2py
     GIT_REPOSITORY https://github.com/flatironinstitute/c2py
-    GIT_TAG        unstable
+    GIT_TAG        doc
     EXCLUDE_FROM_ALL
   )
   FetchContent_MakeAvailable(c2py)

--- a/examples/python_interface/interaction/03_isdf.py
+++ b/examples/python_interface/interaction/03_isdf.py
@@ -1,0 +1,31 @@
+"""
+
+Example: Interpolative separable density fitting from QE mean-field object
+
+This example demonstrates how to perform interpolative separable density fitting (ISDF)
+for the pair densities and dump the results to hdf5.
+"""
+
+from mpi4py import MPI
+import coqui
+
+qe_dir = coqui.TEST_INPUT_DIR + "qe/svo_kp222_nbnd40/out"
+
+mpi = coqui.MpiHandler()
+coqui.set_verbosity(mpi, output_level=1)
+
+# --- Build Mf object from QE results
+mf_params = {
+    "prefix": "svo",      # prefix of the QE scf/nscf
+    "outdir": qe_dir      # outdir of the QE scf/nscf
+}
+svo_mf = coqui.make_mf(mpi, params=mf_params, mf_type="qe")
+
+# --- ISDF for pair densities and dump to hdf5
+isdf_params = {
+    "ecut": 40,
+    "thresh": 1e-4,
+    "save": "svo_isdf.h5",
+    "write_zeta_on_fft_mesh": True
+}
+coqui.run_isdf(mf=svo_mf, params=isdf_params)

--- a/src/methods/ERI/thc.cpp
+++ b/src/methods/ERI/thc.cpp
@@ -404,17 +404,48 @@ void thc::save(h5::group& gh5, std::string format, memory::array<MEM,long,1> con
 
 template<MEMORY_SPACE MEM>
 void thc::save(h5::group& gh5, std::string format, memory::array<MEM,long,1> const& ri,
-               memory::darray_t<memory::array<MEM,ComplexType,3>,mpi3::communicator> const& zeta_qur)
+               memory::darray_t<memory::array<MEM,ComplexType,3>,mpi3::communicator> const& zeta_qur,
+               bool write_zeta_on_fft_mesh)
 {
   Timer.start("TOTAL");
   utils::memory_report(3, "thc::save");
   Timer.start("IO_SAVE");
   if(format == "default" or format == "bdft") {
+
+    memory::array<MEM, ComplexType, 3> zeta_qur_local;
     if(mpi->comm.root()) {
       auto ri_h = nda::to_host(ri);
       nda::h5_write(gh5, "interpolating_points", ri_h, false);
+
+      zeta_qur_local = memory::array<MEM, ComplexType, 3>(zeta_qur.global_shape());
+      math::nda::gather(0, zeta_qur, &zeta_qur_local);
+
+      if (mf->has_wfc_grid()) {
+
+        nda::h5_write(gh5, "fft_mesh", rho_g.mesh(), false);
+
+        if (write_zeta_on_fft_mesh) {
+          memory::array<MEM, ComplexType, 3> zeta_qur_fft(
+              zeta_qur_local.shape(0), zeta_qur_local.shape(1), rho_g.nnr());
+          zeta_qur_fft() = 0.0;
+          for (auto [i, n]: itertools::enumerate(rho_g.gv_to_fft())) {
+            zeta_qur_fft(nda::range::all, nda::range::all, n) =
+                zeta_qur_local(nda::range::all, nda::range::all, i);
+          }
+          nda::h5_write(gh5, "interpolating_vectors", zeta_qur_fft, false);
+        } else {
+          nda::h5_write(gh5, "interpolating_vectors", zeta_qur_local, false);
+          nda::h5_write(gh5, "g_vectors", rho_g.g_vectors(), false);
+          nda::h5_write(gh5, "gv_to_fft", rho_g.gv_to_fft(), false);
+        }
+
+      } else {
+          nda::h5_write(gh5, "interpolating_vectors", zeta_qur_local, false);
+      }
+
+    } else {
+      gather(0, zeta_qur, &zeta_qur_local);
     }
-    math::nda::h5_write(gh5, "interpolating_vectors", zeta_qur);
   } else
     APP_ABORT("Error: Unknown format type: {}",format);
   Timer.stop("IO_SAVE");
@@ -620,7 +651,7 @@ template void thc::save<HOST_MEMORY>(h5::group&,std::string,memory::host_array<l
     memory::host_array<ComplexType, 2> const&, memory::host_array<ComplexType, 2> const&);
 
 template void thc::save<HOST_MEMORY>(h5::group&,std::string,memory::host_array<long,1> const&,
-    darray_t<memory::host_array<ComplexType,3>,communicator> const&);
+    darray_t<memory::host_array<ComplexType,3>,communicator> const&, bool);
 
 #if defined(ENABLE_DEVICE)
 

--- a/src/methods/ERI/thc.h
+++ b/src/methods/ERI/thc.h
@@ -294,7 +294,8 @@ class thc
    */
   template<MEMORY_SPACE MEM = HOST_MEMORY>
   void save(h5::group& gh5, std::string format, memory::array<MEM,long,1> const& ri,
-            memory::darray_t<memory::array<MEM,ComplexType,3>,mpi3::communicator> const& zeta_qur);
+            memory::darray_t<memory::array<MEM,ComplexType,3>,mpi3::communicator> const& zeta_qur,
+            bool write_zeta_on_fft_mesh=false);
 
   // writes metadata to h5 file, includes all information in addition to actual
   // thc vectors. File should be self-contained upon read

--- a/src/methods/ERI/thc_reader_t.hpp
+++ b/src/methods/ERI/thc_reader_t.hpp
@@ -106,7 +106,8 @@ namespace methods {
 
       if (intialize) {
         if (isdf_only) {
-          build_isdf_only(io::get_value_with_default<bool>(pt, "check_accuracy", false));
+          build_isdf_only(io::get_value_with_default<bool>(pt, "check_accuracy", false),
+                          io::get_value_with_default<bool>(pt, "write_zeta_on_fft_mesh", false));
         } else {
           init(true);
         }
@@ -455,7 +456,7 @@ namespace methods {
       print_thc_summary();
     }
 
-    void build_isdf_only(bool check_accuracy=true) {
+    void build_isdf_only(bool check_accuracy=true, bool write_zeta_on_fft_mesh=false) {
       _Timer.start("BUILD_TOTAL");
 
       _Timer.start("BUILD_ISDF");
@@ -494,14 +495,14 @@ namespace methods {
             h5::h5_write(grp, "nkpts_ibz", _nkpts_ibz);
             h5::h5_write(grp, "nqpts_ibz", _nqpts_ibz);
             nda::h5_write(grp, "collocation_matrix", _X_shm.local(), false);
-            _thc_builder_opt.value().save(grp, _format, _rp, dzeta_qur);
+            _thc_builder_opt.value().save(grp, _format, _rp, dzeta_qur, write_zeta_on_fft_mesh);
           } else {
             APP_ABORT("thc: Unknown file format: {}", _format);
           }
         } else {
           h5::group grp;
           if(_format == "bdft" ) {
-            _thc_builder_opt.value().save(grp, _format, _rp, dzeta_qur);
+            _thc_builder_opt.value().save(grp, _format, _rp, dzeta_qur, write_zeta_on_fft_mesh);
           } else {
             APP_ABORT("thc: Unknown file format: {}", _format);
           }

--- a/src/python/__init__.py
+++ b/src/python/__init__.py
@@ -45,7 +45,7 @@ from .version import *
 # Direct api for important routines
 from .utils import set_verbosity, MpiHandler
 from .mean_field import make_mf
-from .interaction import make_thc_coulomb, make_chol_coulomb
+from .interaction import make_thc_coulomb, make_chol_coulomb, run_isdf
 from .mbpt import run_hf, run_gw, run_qpg0w0
 from .embed import downfold_1e, downfold_2e, downfold_local_gf, downfold_local_coulomb, dmft_embed
 from .wannier import wannier90,coqui2wannier90,append_wannier90_win

--- a/src/python/embed/embed_module.wrap.cxx
+++ b/src/python/embed/embed_module.wrap.cxx
@@ -184,12 +184,18 @@ static auto const fun_5 = c2py::dispatcher_f_kw_t{
         "eri", "df_params", "C_ksIai", "band_window", "kpts_crys",
         "local_polarizabilities")};
 
-static const auto doc_d_0 = fun_0.doc(R"DOC()DOC");
-static const auto doc_d_1 = fun_1.doc(R"DOC()DOC");
-static const auto doc_d_2 = fun_2.doc(R"DOC()DOC");
-static const auto doc_d_3 = fun_3.doc(R"DOC()DOC");
-static const auto doc_d_4 = fun_4.doc(R"DOC()DOC");
-static const auto doc_d_5 = fun_5.doc(R"DOC()DOC");
+static const auto doc_d_0 = fun_0.doc(R"DOC()DOC", std::vector<std::string>{},
+                                      std::vector<std::string>{});
+static const auto doc_d_1 = fun_1.doc(R"DOC()DOC", std::vector<std::string>{},
+                                      std::vector<std::string>{});
+static const auto doc_d_2 = fun_2.doc(R"DOC()DOC", std::vector<std::string>{},
+                                      std::vector<std::string>{});
+static const auto doc_d_3 = fun_3.doc(R"DOC()DOC", std::vector<std::string>{},
+                                      std::vector<std::string>{});
+static const auto doc_d_4 = fun_4.doc(R"DOC()DOC", std::vector<std::string>{},
+                                      std::vector<std::string>{});
+static const auto doc_d_5 = fun_5.doc(R"DOC()DOC", std::vector<std::string>{},
+                                      std::vector<std::string>{});
 //--------------------- module function table  -----------------------------
 
 static PyMethodDef module_methods[] = {

--- a/src/python/interaction/__init__.py
+++ b/src/python/interaction/__init__.py
@@ -18,9 +18,9 @@ limitations under the License.
 ==========================================================================
 """
 
-from .thc import make_thc_coulomb
+from .thc import make_thc_coulomb, run_isdf
 from .cholesky import make_chol_coulomb
 
 from . import pyscf_interface
 
-__all__ = ["make_thc_coulomb", "make_chol_coulomb"]
+__all__ = ["make_thc_coulomb", "make_chol_coulomb", "run_isdf"]

--- a/src/python/interaction/eri_module.hpp
+++ b/src/python/interaction/eri_module.hpp
@@ -32,6 +32,11 @@
 
 namespace coqui_py {
 
+  void run_isdf(const Mf &mf, const std::string &thc_params) {
+    auto parser = InputParser(thc_params);
+    methods::make_isdf(mf.get_mf(), parser.get_root());
+  }
+
   C2PY_IGNORE
   inline decltype(auto) make_thc(const Mf &mf, const std::string &thc_params) {
     auto parser = InputParser(thc_params);

--- a/src/python/interaction/eri_module.toml
+++ b/src/python/interaction/eri_module.toml
@@ -17,7 +17,7 @@ namespaces = ""
 #    if reject_names and reject_names matches Qname : skip X
 #    else keep X.
 #
-match_names = "coqui_py::(ThcCoulomb|CholCoulomb)"
+match_names = "coqui_py::(ThcCoulomb|CholCoulomb|run_isdf)"
 reject_names = ""
 
 # If true, transform methods with no arguments into a read only property

--- a/src/python/interaction/eri_module.wrap.cxx
+++ b/src/python/interaction/eri_module.wrap.cxx
@@ -51,16 +51,15 @@ template <> constexpr bool c2py::is_wrapped<coqui_py::CholCoulomb> = true;
 template <>
 inline constexpr auto c2py::tp_name<coqui_py::ThcCoulomb> =
     "eri_module.ThcCoulomb";
-template <>
-inline constexpr const char *c2py::tp_doc<coqui_py::ThcCoulomb> =
-    R"DOC(   )DOC";
-
 static auto init_0 = c2py::dispatcher_c_kw_t{
     c2py::c_constructor<coqui_py::ThcCoulomb, const coqui_py::Mf &,
                         const std::string &>("mf", "thc_params")};
 template <>
 constexpr initproc c2py::tp_init<coqui_py::ThcCoulomb> =
     c2py::pyfkw_constructor<init_0>;
+template <>
+const std::string c2py::tp_ctor_doc<coqui_py::ThcCoulomb> = init_0.doc(
+    R"DOC()DOC", std::vector<std::string>{}, std::vector<std::string>{});
 // Np
 static auto const fun_0 = c2py::dispatcher_f_kw_t{c2py::cmethod(
     [](coqui_py::ThcCoulomb const &self) { return self.Np(); }, "self")};
@@ -110,18 +109,31 @@ static auto const fun_10 = c2py::dispatcher_f_kw_t{c2py::cmethod(
 static auto const fun_11 = c2py::dispatcher_f_kw_t{c2py::cmethod(
     [](coqui_py::ThcCoulomb const &self) { return self.nspin_in_basis(); },
     "self")};
-static const auto doc_d_0 = fun_0.doc(R"DOC()DOC");
-static const auto doc_d_1 = fun_1.doc(R"DOC()DOC");
-static const auto doc_d_2 = fun_2.doc(R"DOC()DOC");
-static const auto doc_d_3 = fun_3.doc(R"DOC()DOC");
-static const auto doc_d_4 = fun_4.doc(R"DOC()DOC");
-static const auto doc_d_5 = fun_5.doc(R"DOC()DOC");
-static const auto doc_d_6 = fun_6.doc(R"DOC()DOC");
-static const auto doc_d_7 = fun_7.doc(R"DOC()DOC");
-static const auto doc_d_8 = fun_8.doc(R"DOC()DOC");
-static const auto doc_d_9 = fun_9.doc(R"DOC()DOC");
-static const auto doc_d_10 = fun_10.doc(R"DOC()DOC");
-static const auto doc_d_11 = fun_11.doc(R"DOC()DOC");
+
+static const auto doc_d_0 = fun_0.doc(R"DOC()DOC", std::vector<std::string>{},
+                                      std::vector<std::string>{});
+static const auto doc_d_1 = fun_1.doc(R"DOC()DOC", std::vector<std::string>{},
+                                      std::vector<std::string>{});
+static const auto doc_d_2 = fun_2.doc(R"DOC()DOC", std::vector<std::string>{},
+                                      std::vector<std::string>{});
+static const auto doc_d_3 = fun_3.doc(R"DOC()DOC", std::vector<std::string>{},
+                                      std::vector<std::string>{});
+static const auto doc_d_4 = fun_4.doc(R"DOC()DOC", std::vector<std::string>{},
+                                      std::vector<std::string>{});
+static const auto doc_d_5 = fun_5.doc(R"DOC()DOC", std::vector<std::string>{},
+                                      std::vector<std::string>{});
+static const auto doc_d_6 = fun_6.doc(R"DOC()DOC", std::vector<std::string>{},
+                                      std::vector<std::string>{});
+static const auto doc_d_7 = fun_7.doc(R"DOC()DOC", std::vector<std::string>{},
+                                      std::vector<std::string>{});
+static const auto doc_d_8 = fun_8.doc(R"DOC()DOC", std::vector<std::string>{},
+                                      std::vector<std::string>{});
+static const auto doc_d_9 = fun_9.doc(R"DOC()DOC", std::vector<std::string>{},
+                                      std::vector<std::string>{});
+static const auto doc_d_10 = fun_10.doc(R"DOC()DOC", std::vector<std::string>{},
+                                        std::vector<std::string>{});
+static const auto doc_d_11 = fun_11.doc(R"DOC()DOC", std::vector<std::string>{},
+                                        std::vector<std::string>{});
 
 // ----- Method table ----
 template <>
@@ -161,18 +173,20 @@ constinit PyGetSetDef c2py::tp_getset<coqui_py::ThcCoulomb>[] = {
     {nullptr, nullptr, nullptr, nullptr, nullptr}};
 
 template <>
+const std::string c2py::tp_doc<coqui_py::ThcCoulomb> =
+    R"DOC()DOC" + c2py::tp_ctor_doc<coqui_py::ThcCoulomb>;
+template <>
 inline constexpr auto c2py::tp_name<coqui_py::CholCoulomb> =
     "eri_module.CholCoulomb";
-template <>
-inline constexpr const char *c2py::tp_doc<coqui_py::CholCoulomb> =
-    R"DOC(   )DOC";
-
 static auto init_1 = c2py::dispatcher_c_kw_t{
     c2py::c_constructor<coqui_py::CholCoulomb, const coqui_py::Mf &,
                         const std::string &>("mf", "chol_params")};
 template <>
 constexpr initproc c2py::tp_init<coqui_py::CholCoulomb> =
     c2py::pyfkw_constructor<init_1>;
+template <>
+const std::string c2py::tp_ctor_doc<coqui_py::CholCoulomb> = init_1.doc(
+    R"DOC()DOC", std::vector<std::string>{}, std::vector<std::string>{});
 // mf
 static auto const fun_12 = c2py::dispatcher_f_kw_t{c2py::cmethod(
     [](coqui_py::CholCoulomb const &self) { return self.mf(); }, "self")};
@@ -180,8 +194,11 @@ static auto const fun_12 = c2py::dispatcher_f_kw_t{c2py::cmethod(
 // mpi
 static auto const fun_13 = c2py::dispatcher_f_kw_t{c2py::cmethod(
     [](coqui_py::CholCoulomb const &self) { return self.mpi(); }, "self")};
-static const auto doc_d_12 = fun_12.doc(R"DOC()DOC");
-static const auto doc_d_13 = fun_13.doc(R"DOC()DOC");
+
+static const auto doc_d_12 = fun_12.doc(R"DOC()DOC", std::vector<std::string>{},
+                                        std::vector<std::string>{});
+static const auto doc_d_13 = fun_13.doc(R"DOC()DOC", std::vector<std::string>{},
+                                        std::vector<std::string>{});
 
 // ----- Method table ----
 template <>
@@ -200,11 +217,26 @@ constinit PyGetSetDef c2py::tp_getset<coqui_py::CholCoulomb>[] = {
 
     {nullptr, nullptr, nullptr, nullptr, nullptr}};
 
+template <>
+const std::string c2py::tp_doc<coqui_py::CholCoulomb> =
+    R"DOC()DOC" + c2py::tp_ctor_doc<coqui_py::CholCoulomb>;
+
 // ==================== module functions ====================
 
+// run_isdf
+static auto const fun_14 = c2py::dispatcher_f_kw_t{c2py::cfun(
+    [](const coqui_py::Mf &mf, const std::string &thc_params) {
+      return coqui_py::run_isdf(mf, thc_params);
+    },
+    "mf", "thc_params")};
+
+static const auto doc_d_14 = fun_14.doc(R"DOC()DOC", std::vector<std::string>{},
+                                        std::vector<std::string>{});
 //--------------------- module function table  -----------------------------
 
 static PyMethodDef module_methods[] = {
+    {"run_isdf", (PyCFunction)c2py::pyfkw<fun_14>, METH_VARARGS | METH_KEYWORDS,
+     doc_d_14.c_str()},
     {nullptr, nullptr, 0, nullptr} // Sentinel
 };
 

--- a/src/python/interaction/eri_module.wrap.hxx
+++ b/src/python/interaction/eri_module.wrap.hxx
@@ -3,5 +3,11 @@
 #ifndef C2PY_HXX_DECLARATION_eri_module_GUARDS
 #define C2PY_HXX_DECLARATION_eri_module_GUARDS
 template <> constexpr bool c2py::is_wrapped<coqui_py::ThcCoulomb> = true;
+template <>
+inline constexpr auto c2py::tp_name<coqui_py::ThcCoulomb> =
+    "eri_module.ThcCoulomb";
 template <> constexpr bool c2py::is_wrapped<coqui_py::CholCoulomb> = true;
+template <>
+inline constexpr auto c2py::tp_name<coqui_py::CholCoulomb> =
+    "eri_module.CholCoulomb";
 #endif

--- a/src/python/interaction/thc.py
+++ b/src/python/interaction/thc.py
@@ -21,6 +21,7 @@ limitations under the License.
 import json
 
 from coqui._lib.eri_module import ThcCoulomb
+from coqui._lib.eri_module import run_isdf as isdf_cxx
 
 def thc_default_params():
   """
@@ -92,3 +93,8 @@ def make_thc_coulomb(mf, params):
   CoQui ThcCoulomb class
   """
   return ThcCoulomb(mf, json.dumps(params))
+
+
+def run_isdf(mf, params):
+    isdf_cxx(mf, json.dumps(params))
+

--- a/src/python/mbpt/mbpt_module.wrap.cxx
+++ b/src/python/mbpt/mbpt_module.wrap.cxx
@@ -184,7 +184,8 @@ static auto const fun_0 = c2py::dispatcher_f_kw_t{
         "solver_type", "mbpt_params", "h_int", "h_int_hartree",
         "h_int_exchange")};
 
-static const auto doc_d_0 = fun_0.doc(R"DOC()DOC");
+static const auto doc_d_0 = fun_0.doc(R"DOC()DOC", std::vector<std::string>{},
+                                      std::vector<std::string>{});
 //--------------------- module function table  -----------------------------
 
 static PyMethodDef module_methods[] = {

--- a/src/python/mean_field/mf_module.wrap.cxx
+++ b/src/python/mean_field/mf_module.wrap.cxx
@@ -48,17 +48,15 @@ template <> constexpr bool c2py::is_wrapped<coqui_py::Mf> = true;
 // ==================== module classes =====================
 
 template <> inline constexpr auto c2py::tp_name<coqui_py::Mf> = "mf_module.Mf";
-template <>
-inline constexpr const char *c2py::tp_doc<coqui_py::Mf> =
-    R"DOC(   The Mf class encapsulates the state of a mean-field inputs to CoQuí. This class is read-only and is responsible for accessing the input data, including
-   1. Metadata of the simulated system, such as the number of bands, spins, and k-points. 2. Single-particle basis functions whom CoQuí uses to construct a many-body Hamiltonian in CoQuí.)DOC";
-
 static auto init_0 = c2py::dispatcher_c_kw_t{
     c2py::c_constructor<coqui_py::Mf, coqui_py::MpiHandler &, std::string,
                         const std::string &>("mpi", "mf_params", "mf_type")};
 template <>
 constexpr initproc c2py::tp_init<coqui_py::Mf> =
     c2py::pyfkw_constructor<init_0>;
+template <>
+const std::string c2py::tp_ctor_doc<coqui_py::Mf> = init_0.doc(
+    R"DOC()DOC", std::vector<std::string>{}, std::vector<std::string>{});
 // ecutrho
 static auto const fun_0 = c2py::dispatcher_f_kw_t{c2py::cmethod(
     [](coqui_py::Mf const &self) { return self.ecutrho(); }, "self")};
@@ -150,29 +148,53 @@ static auto const fun_21 = c2py::dispatcher_f_kw_t{c2py::cmethod(
 // qpts_ibz
 static auto const fun_22 = c2py::dispatcher_f_kw_t{c2py::cmethod(
     [](coqui_py::Mf const &self) { return self.qpts_ibz(); }, "self")};
-static const auto doc_d_0 = fun_0.doc(R"DOC()DOC");
-static const auto doc_d_1 = fun_1.doc(R"DOC()DOC");
-static const auto doc_d_2 = fun_2.doc(R"DOC()DOC");
-static const auto doc_d_3 = fun_3.doc(R"DOC()DOC");
-static const auto doc_d_4 = fun_4.doc(R"DOC()DOC");
-static const auto doc_d_5 = fun_5.doc(R"DOC()DOC");
-static const auto doc_d_6 = fun_6.doc(R"DOC()DOC");
-static const auto doc_d_7 = fun_7.doc(R"DOC()DOC");
-static const auto doc_d_8 = fun_8.doc(R"DOC()DOC");
-static const auto doc_d_9 = fun_9.doc(R"DOC()DOC");
-static const auto doc_d_10 = fun_10.doc(R"DOC()DOC");
-static const auto doc_d_11 = fun_11.doc(R"DOC()DOC");
-static const auto doc_d_12 = fun_12.doc(R"DOC()DOC");
-static const auto doc_d_13 = fun_13.doc(R"DOC()DOC");
-static const auto doc_d_14 = fun_14.doc(R"DOC()DOC");
-static const auto doc_d_15 = fun_15.doc(R"DOC()DOC");
-static const auto doc_d_16 = fun_16.doc(R"DOC()DOC");
-static const auto doc_d_17 = fun_17.doc(R"DOC()DOC");
-static const auto doc_d_18 = fun_18.doc(R"DOC()DOC");
-static const auto doc_d_19 = fun_19.doc(R"DOC()DOC");
-static const auto doc_d_20 = fun_20.doc(R"DOC()DOC");
-static const auto doc_d_21 = fun_21.doc(R"DOC()DOC");
-static const auto doc_d_22 = fun_22.doc(R"DOC()DOC");
+
+static const auto doc_d_0 = fun_0.doc(R"DOC()DOC", std::vector<std::string>{},
+                                      std::vector<std::string>{});
+static const auto doc_d_1 = fun_1.doc(R"DOC()DOC", std::vector<std::string>{},
+                                      std::vector<std::string>{});
+static const auto doc_d_2 = fun_2.doc(R"DOC()DOC", std::vector<std::string>{},
+                                      std::vector<std::string>{});
+static const auto doc_d_3 = fun_3.doc(R"DOC()DOC", std::vector<std::string>{},
+                                      std::vector<std::string>{});
+static const auto doc_d_4 = fun_4.doc(R"DOC()DOC", std::vector<std::string>{},
+                                      std::vector<std::string>{});
+static const auto doc_d_5 = fun_5.doc(R"DOC()DOC", std::vector<std::string>{},
+                                      std::vector<std::string>{});
+static const auto doc_d_6 = fun_6.doc(R"DOC()DOC", std::vector<std::string>{},
+                                      std::vector<std::string>{});
+static const auto doc_d_7 = fun_7.doc(R"DOC()DOC", std::vector<std::string>{},
+                                      std::vector<std::string>{});
+static const auto doc_d_8 = fun_8.doc(R"DOC()DOC", std::vector<std::string>{},
+                                      std::vector<std::string>{});
+static const auto doc_d_9 = fun_9.doc(R"DOC()DOC", std::vector<std::string>{},
+                                      std::vector<std::string>{});
+static const auto doc_d_10 = fun_10.doc(R"DOC()DOC", std::vector<std::string>{},
+                                        std::vector<std::string>{});
+static const auto doc_d_11 = fun_11.doc(R"DOC()DOC", std::vector<std::string>{},
+                                        std::vector<std::string>{});
+static const auto doc_d_12 = fun_12.doc(R"DOC()DOC", std::vector<std::string>{},
+                                        std::vector<std::string>{});
+static const auto doc_d_13 = fun_13.doc(R"DOC()DOC", std::vector<std::string>{},
+                                        std::vector<std::string>{});
+static const auto doc_d_14 = fun_14.doc(R"DOC()DOC", std::vector<std::string>{},
+                                        std::vector<std::string>{});
+static const auto doc_d_15 = fun_15.doc(R"DOC()DOC", std::vector<std::string>{},
+                                        std::vector<std::string>{});
+static const auto doc_d_16 = fun_16.doc(R"DOC()DOC", std::vector<std::string>{},
+                                        std::vector<std::string>{});
+static const auto doc_d_17 = fun_17.doc(R"DOC()DOC", std::vector<std::string>{},
+                                        std::vector<std::string>{});
+static const auto doc_d_18 = fun_18.doc(R"DOC()DOC", std::vector<std::string>{},
+                                        std::vector<std::string>{});
+static const auto doc_d_19 = fun_19.doc(R"DOC()DOC", std::vector<std::string>{},
+                                        std::vector<std::string>{});
+static const auto doc_d_20 = fun_20.doc(R"DOC()DOC", std::vector<std::string>{},
+                                        std::vector<std::string>{});
+static const auto doc_d_21 = fun_21.doc(R"DOC()DOC", std::vector<std::string>{},
+                                        std::vector<std::string>{});
+static const auto doc_d_22 = fun_22.doc(R"DOC()DOC", std::vector<std::string>{},
+                                        std::vector<std::string>{});
 
 // ----- Method table ----
 template <>
@@ -232,6 +254,17 @@ template <>
 constinit PyGetSetDef c2py::tp_getset<coqui_py::Mf>[] = {
 
     {nullptr, nullptr, nullptr, nullptr, nullptr}};
+
+template <>
+const std::string c2py::tp_doc<coqui_py::Mf> =
+    R"DOC(Mf class
+
+The Mf class encapsulates the state of a mean-field inputs to CoQuí.
+This class is read-only and is responsible for accessing the input data, including
+
+  1. Metadata of the simulated system, such as the number of bands, spins, and k-points.
+  2. Single-particle basis functions whom CoQuí uses to construct a many-body Hamiltonian in CoQuí.)DOC" +
+    std::string{"\n\n----------\n\n"} + c2py::tp_ctor_doc<coqui_py::Mf>;
 
 // ==================== module functions ====================
 

--- a/src/python/mean_field/mf_module.wrap.hxx
+++ b/src/python/mean_field/mf_module.wrap.hxx
@@ -3,4 +3,5 @@
 #ifndef C2PY_HXX_DECLARATION_mf_module_GUARDS
 #define C2PY_HXX_DECLARATION_mf_module_GUARDS
 template <> constexpr bool c2py::is_wrapped<coqui_py::Mf> = true;
+template <> inline constexpr auto c2py::tp_name<coqui_py::Mf> = "mf_module.Mf";
 #endif

--- a/src/python/mean_field/pyscf_interface/converter.py
+++ b/src/python/mean_field/pyscf_interface/converter.py
@@ -51,7 +51,7 @@ def dump_to_h5(mf, mo=False, outdir='./', prefix='pyscf', nbnd_out=None):
 
   kp_grid = tools.get_monkhorst_pack_size(mf.cell, mf.kpts)
   kpts = mf.cell.make_kpts(kp_grid)
-  assert(np.array_equal(kpts, mf.kpts), "kpts mismatch!")
+  assert np.array_equal(kpts, mf.kpts), "kpts mismatch!"
 
   nkpts, nbnd = len(mf.kpts), mf.cell.nao_nr()
   S, H0, dm = mf.get_ovlp(), mf.get_hcore(), mf.make_rdm1()

--- a/src/python/post_proc/post_proc_module.wrap.cxx
+++ b/src/python/post_proc/post_proc_module.wrap.cxx
@@ -96,13 +96,20 @@ static auto const fun_6 = c2py::dispatcher_f_kw_t{c2py::cfun(
     },
     "mf", "params")};
 
-static const auto doc_d_0 = fun_0.doc(R"DOC()DOC");
-static const auto doc_d_1 = fun_1.doc(R"DOC()DOC");
-static const auto doc_d_2 = fun_2.doc(R"DOC()DOC");
-static const auto doc_d_3 = fun_3.doc(R"DOC()DOC");
-static const auto doc_d_4 = fun_4.doc(R"DOC()DOC");
-static const auto doc_d_5 = fun_5.doc(R"DOC()DOC");
-static const auto doc_d_6 = fun_6.doc(R"DOC()DOC");
+static const auto doc_d_0 = fun_0.doc(R"DOC()DOC", std::vector<std::string>{},
+                                      std::vector<std::string>{});
+static const auto doc_d_1 = fun_1.doc(R"DOC()DOC", std::vector<std::string>{},
+                                      std::vector<std::string>{});
+static const auto doc_d_2 = fun_2.doc(R"DOC()DOC", std::vector<std::string>{},
+                                      std::vector<std::string>{});
+static const auto doc_d_3 = fun_3.doc(R"DOC()DOC", std::vector<std::string>{},
+                                      std::vector<std::string>{});
+static const auto doc_d_4 = fun_4.doc(R"DOC()DOC", std::vector<std::string>{},
+                                      std::vector<std::string>{});
+static const auto doc_d_5 = fun_5.doc(R"DOC()DOC", std::vector<std::string>{},
+                                      std::vector<std::string>{});
+static const auto doc_d_6 = fun_6.doc(R"DOC()DOC", std::vector<std::string>{},
+                                      std::vector<std::string>{});
 //--------------------- module function table  -----------------------------
 
 static PyMethodDef module_methods[] = {

--- a/src/python/utils/mpi_handler.wrap.cxx
+++ b/src/python/utils/mpi_handler.wrap.cxx
@@ -50,16 +50,14 @@ template <> constexpr bool c2py::is_wrapped<coqui_py::MpiHandler> = true;
 template <>
 inline constexpr auto c2py::tp_name<coqui_py::MpiHandler> =
     "mpi_handler.MpiHandler";
-template <>
-inline constexpr const char *c2py::tp_doc<coqui_py::MpiHandler> =
-    R"DOC(   The MpiHandler class encapsulates the state of a MPI environment used by CoQui. It manages key information such as the total number of processors, node distribution, and provides access to global, internode, and intranode communicators.
-   This class also offers a minimal interface for performing basic MPI operations. It must be constructed and passed to any CoQuí routines that involve MPI parallelization. Even in serial mode (i.e., when using a single process), this class is required to ensure a consistent interface across all workflows.)DOC";
-
 static auto init_0 =
     c2py::dispatcher_c_kw_t{c2py::c_constructor<coqui_py::MpiHandler>()};
 template <>
 constexpr initproc c2py::tp_init<coqui_py::MpiHandler> =
     c2py::pyfkw_constructor<init_0>;
+template <>
+const std::string c2py::tp_ctor_doc<coqui_py::MpiHandler> = init_0.doc(
+    R"DOC()DOC", std::vector<std::string>{}, std::vector<std::string>{});
 // barrier
 static auto const fun_0 = c2py::dispatcher_f_kw_t{c2py::cmethod(
     [](coqui_py::MpiHandler const &self) { return self.barrier(); }, "self")};
@@ -105,83 +103,92 @@ static auto const fun_8 = c2py::dispatcher_f_kw_t{c2py::cmethod(
 // root
 static auto const fun_9 = c2py::dispatcher_f_kw_t{c2py::cmethod(
     [](coqui_py::MpiHandler const &self) { return self.root(); }, "self")};
-static const auto doc_d_0 = fun_0.doc(R"DOC(
+
+static const auto doc_d_0 =
+    fun_0.doc(R"DOC(
 MPI barrier for the global communicator.
-
-.. raw:: html
-
-   <hr>
-)DOC");
-static const auto doc_d_1 = fun_1.doc(R"DOC(
-**Returns**
+)DOC",
+              std::vector<std::string>{}, std::vector<std::string>{});
+static const auto doc_d_1 =
+    fun_1.doc(R"DOC(
+Returns
+-------
+{ret_0}
    the rank of the current process in the global communicator.
-
-   .. raw:: html
-
-      <hr>
-)DOC");
-static const auto doc_d_2 = fun_2.doc(R"DOC(
-**Returns**
+)DOC",
+              std::vector<std::string>{},
+              std::vector<std::string>{
+                  std::vector<std::string>{c2py::python_typename<int>()}});
+static const auto doc_d_2 =
+    fun_2.doc(R"DOC(
+Returns
+-------
+{ret_0}
    the size of the global communicator, i.e., the total number of processes.
-
-   .. raw:: html
-
-      <hr>
-)DOC");
-static const auto doc_d_3 = fun_3.doc(R"DOC(
+)DOC",
+              std::vector<std::string>{},
+              std::vector<std::string>{
+                  std::vector<std::string>{c2py::python_typename<int>()}});
+static const auto doc_d_3 =
+    fun_3.doc(R"DOC(
 MPI barrier for the internode communicator.
-
-.. raw:: html
-
-   <hr>
-)DOC");
-static const auto doc_d_4 = fun_4.doc(R"DOC(
-**Returns**
+)DOC",
+              std::vector<std::string>{}, std::vector<std::string>{});
+static const auto doc_d_4 =
+    fun_4.doc(R"DOC(
+Returns
+-------
+{ret_0}
    the rank of the current process in the internode communicator.
-
-   .. raw:: html
-
-      <hr>
-)DOC");
-static const auto doc_d_5 = fun_5.doc(R"DOC(
-**Returns**
+)DOC",
+              std::vector<std::string>{},
+              std::vector<std::string>{
+                  std::vector<std::string>{c2py::python_typename<int>()}});
+static const auto doc_d_5 =
+    fun_5.doc(R"DOC(
+Returns
+-------
+{ret_0}
    the size of the internode communicator, i.e., the number of nodes.
-
-   .. raw:: html
-
-      <hr>
-)DOC");
-static const auto doc_d_6 = fun_6.doc(R"DOC(
+)DOC",
+              std::vector<std::string>{},
+              std::vector<std::string>{
+                  std::vector<std::string>{c2py::python_typename<int>()}});
+static const auto doc_d_6 =
+    fun_6.doc(R"DOC(
 MPI barrier for the intranode communicator.
-
-.. raw:: html
-
-   <hr>
-)DOC");
-static const auto doc_d_7 = fun_7.doc(R"DOC(
-**Returns**
+)DOC",
+              std::vector<std::string>{}, std::vector<std::string>{});
+static const auto doc_d_7 =
+    fun_7.doc(R"DOC(
+Returns
+-------
+{ret_0}
    the rank of the current process in the intranode communicator.
-
-   .. raw:: html
-
-      <hr>
-)DOC");
-static const auto doc_d_8 = fun_8.doc(R"DOC(
-**Returns**
+)DOC",
+              std::vector<std::string>{},
+              std::vector<std::string>{
+                  std::vector<std::string>{c2py::python_typename<int>()}});
+static const auto doc_d_8 =
+    fun_8.doc(R"DOC(
+Returns
+-------
+{ret_0}
    the size of the intranode communicator, i.e., the number of processes within a node.
-
-   .. raw:: html
-
-      <hr>
-)DOC");
-static const auto doc_d_9 = fun_9.doc(R"DOC(
-**Returns**
+)DOC",
+              std::vector<std::string>{},
+              std::vector<std::string>{
+                  std::vector<std::string>{c2py::python_typename<int>()}});
+static const auto doc_d_9 =
+    fun_9.doc(R"DOC(
+Returns
+-------
+{ret_0}
    true if the current process is the root, false otherwise.
-
-   .. raw:: html
-
-      <hr>
-)DOC");
+)DOC",
+              std::vector<std::string>{},
+              std::vector<std::string>{
+                  std::vector<std::string>{c2py::python_typename<bool>()}});
 
 // ----- Method table ----
 template <>
@@ -215,6 +222,20 @@ template <>
 constinit PyGetSetDef c2py::tp_getset<coqui_py::MpiHandler>[] = {
 
     {nullptr, nullptr, nullptr, nullptr, nullptr}};
+
+template <>
+const std::string c2py::tp_doc<coqui_py::MpiHandler> =
+    R"DOC(mpi handler class
+
+The MpiHandler class encapsulates the state of a MPI environment used by CoQui.
+It manages key information such as the total number of processors, node distribution,
+and provides access to global, internode, and intranode communicators.
+
+This class also offers a minimal interface for performing basic MPI operations.
+It must be constructed and passed to any CoQuí routines that involve MPI parallelization.
+Even in serial mode (i.e., when using a single process), this class is required to ensure
+a consistent interface across all workflows.)DOC" +
+    std::string{"\n\n----------\n\n"} + c2py::tp_ctor_doc<coqui_py::MpiHandler>;
 
 // ==================== module functions ====================
 

--- a/src/python/utils/mpi_handler.wrap.hxx
+++ b/src/python/utils/mpi_handler.wrap.hxx
@@ -3,4 +3,7 @@
 #ifndef C2PY_HXX_DECLARATION_mpi_handler_GUARDS
 #define C2PY_HXX_DECLARATION_mpi_handler_GUARDS
 template <> constexpr bool c2py::is_wrapped<coqui_py::MpiHandler> = true;
+template <>
+inline constexpr auto c2py::tp_name<coqui_py::MpiHandler> =
+    "mpi_handler.MpiHandler";
 #endif

--- a/src/python/utils/utils_module.wrap.cxx
+++ b/src/python/utils/utils_module.wrap.cxx
@@ -58,26 +58,31 @@ static auto const fun_0 = c2py::dispatcher_f_kw_t{c2py::cfun(
 static auto const fun_1 = c2py::dispatcher_f_kw_t{c2py::cfun(
     [](std::string src) { return coqui_py::utest_filename(src); }, "src")};
 
-static const auto doc_d_0 = fun_0.doc(R"DOC(
+static const auto doc_d_0 = fun_0.doc(
+    R"DOC(
 Set verbosity levels for CoQui logging output.
 
-.. raw:: html
-
-   <hr>
-
-**Parameters**
-   :mpi_handler:
-      - [INPUT] MPI handler to ensure logging is MPI-aware, i.e. only root prints
-   :output_level:
-      - [INPUT] Level of output verbosity (default: 2)
-   :debug_level:
-      - [INPUT] Level of debug verbosity (default: 0)
-
-   .. raw:: html
-
-      <hr>
-)DOC");
-static const auto doc_d_1 = fun_1.doc(R"DOC()DOC");
+Parameters
+----------
+mpi_handler : {par_0}
+   - [INPUT] MPI handler to ensure logging is MPI-aware, i.e. only root prints
+output_level : {par_1}
+   - [INPUT] Level of output verbosity (default: 2)
+debug_level : {par_2}
+   - [INPUT] Level of debug verbosity (default: 0)
+)DOC",
+    std::vector<std::string>{
+        c2py::join(
+            std::vector<std::string>{
+                c2py::python_typename<coqui_py::MpiHandler &>()},
+            ", "),
+        c2py::join(std::vector<std::string>{c2py::python_typename<int>()},
+                   ", "),
+        c2py::join(std::vector<std::string>{c2py::python_typename<int>()},
+                   ", ")},
+    std::vector<std::string>{});
+static const auto doc_d_1 = fun_1.doc(R"DOC()DOC", std::vector<std::string>{},
+                                      std::vector<std::string>{});
 //--------------------- module function table  -----------------------------
 
 static PyMethodDef module_methods[] = {

--- a/src/python/wannier/wannier_module.wrap.cxx
+++ b/src/python/wannier/wannier_module.wrap.cxx
@@ -68,9 +68,12 @@ static auto const fun_2 = c2py::dispatcher_f_kw_t{c2py::cfun(
     },
     "mf", "params")};
 
-static const auto doc_d_0 = fun_0.doc(R"DOC()DOC");
-static const auto doc_d_1 = fun_1.doc(R"DOC()DOC");
-static const auto doc_d_2 = fun_2.doc(R"DOC()DOC");
+static const auto doc_d_0 = fun_0.doc(R"DOC()DOC", std::vector<std::string>{},
+                                      std::vector<std::string>{});
+static const auto doc_d_1 = fun_1.doc(R"DOC()DOC", std::vector<std::string>{},
+                                      std::vector<std::string>{});
+static const auto doc_d_2 = fun_2.doc(R"DOC()DOC", std::vector<std::string>{},
+                                      std::vector<std::string>{});
 //--------------------- module function table  -----------------------------
 
 static PyMethodDef module_methods[] = {


### PR DESCRIPTION
The PR adds a couple missing features in the ISDF routine: 
1. dump isdf interpolating vectors to fft mesh
2. isdf python interface

In addition, c2py is switched to`doc` branch. 