### PR TITLE
make pyscf converter submodule optional 

### DIFF
--- a/src/python/interaction/__init__.py
+++ b/src/python/interaction/__init__.py
@@ -21,6 +21,12 @@ limitations under the License.
 from .thc import make_thc_coulomb, run_isdf
 from .cholesky import make_chol_coulomb
 
-from . import pyscf_interface
+# import PySCF converter module only if PySCF is available
+try:
+    import pyscf
+except ImportError:
+    pass
+else:
+    from . import pyscf_interface
 
 __all__ = ["make_thc_coulomb", "make_chol_coulomb", "run_isdf"]

--- a/src/python/mean_field/__init__.py
+++ b/src/python/mean_field/__init__.py
@@ -20,6 +20,12 @@ limitations under the License.
 
 from .mf import make_mf
 
-from . import pyscf_interface
+# import PySCF converter module only if PySCF is available
+try:
+    import pyscf
+except ImportError:
+    pass
+else:
+    from . import pyscf_interface
 
 __all__ = ["make_mf"]


### PR DESCRIPTION
PR #10 import the pyscf converter submodule at the top level, which implicitly enforces PySCF as a required dependency.  

This PR updates the import logic to make pyscf converter optional,. It is now imported only if PySCF is available in the environment. 