### PR TITLE
Refactor divergence treatment and improve GW+EDMFT loop structure

### DIFF
--- a/examples/python_interface/dmft/gw_edmft/01_gw.py
+++ b/examples/python_interface/dmft/gw_edmft/01_gw.py
@@ -23,12 +23,12 @@ thc = coqui.make_thc_coulomb(mf=mf, params=coqui_params['interaction']['thc'])
 # self-consistent GW as starting point
 gw_params = {
     "restart": False,
-    "output": coqui_params["gw"]["output"],
+    "output": coqui_params["gw_edmft"]["outdir"]+"/"+coqui_params["gw_edmft"]["prefix"],
     "beta": beta,
     "wmax": wmax,
     "iaft_prec": "high",
     "niter": 10,
-    "div_treatment": "gygi_extrplt",
+    "div_treatment": "gygi_metal",
     "iter_alg": {
         "alg": "diis",
         "mixing": 0.6,

--- a/examples/python_interface/dmft/gw_edmft/02_gw_edmft.py
+++ b/examples/python_interface/dmft/gw_edmft/02_gw_edmft.py
@@ -1,4 +1,3 @@
-import numpy as np
 import tomllib
 
 import triqs.utility.mpi as mpi
@@ -13,21 +12,14 @@ wan_h5 = coqui.TEST_INPUT_DIR + "qe/svo_kp222_nbnd40/mlwf/svo.mlwf.h5"
 coqui_mpi = coqui.MpiHandler()
 coqui.set_verbosity(coqui_mpi, output_level=2)
 
-outer_niter, inner_niter = 1, 1
-
 # Define correlated subspace via ModEST
 obe = modest.make_one_body_elements_gw(wan_h5)
-mpi.report("-"*20+"One-Particle Embedding"+"-"*20)
 E1 = modest.make_embedding(obe.C_space)
-mpi.report(E1.description(True))
-mpi.report("-"*20+"Two-Particle Embedding"+"-"*20)
-E2 = modest.make_embedding(obe.C_space, use_atom_decomp=True).make_spinless
-mpi.report(E2.description(True))
 
 # Update the rotation matrix
 proj_info = coqui_dmft.get_proj_info(obe.P)
 
-# read input parameters
+# read input parameters 
 with open("gw_edmft_params.toml", "rb") as f:
     coqui_params = tomllib.load(f)
 
@@ -35,7 +27,4 @@ mf = coqui.make_mf(coqui_mpi, coqui_params['mean_field']['qe'], mf_type='qe')
 thc = coqui.make_thc_coulomb(mf=mf, params=coqui_params['interaction']['thc'])
 
 # GW+EDMFT driver
-coqui_dmft.gw_edmft_loop(
-    mf, thc, proj_info, E1, E2, 
-    inner_niter, outer_niter, **coqui_params
-)
+coqui_dmft.run_gw_edmft(mf, thc, proj_info, E1, **coqui_params)

--- a/examples/python_interface/dmft/gw_edmft/gw_edmft_params.toml
+++ b/examples/python_interface/dmft/gw_edmft/gw_edmft_params.toml
@@ -1,68 +1,97 @@
+################################################################################
+# GW+EDMFT example input
 #
-# A collection of parameters for CoQui GW+EDMFT driver
-#
+# This file is organized in execution order:
+#   1) mean-field input
+#   2) interaction/THC setup
+#   3) GW+EDMFT parameters, including GW and impurity solver controls
+################################################################################
+
+# -----------------------------------------------------------------------------
+# Mean-field source (Quantum ESPRESSO)
+# -----------------------------------------------------------------------------
 [mean_field.qe]
 prefix = "svo"
 outdir = "/mnt/home/cyeh/Projects/coqui/tests/unit_test_files/qe/svo_kp222_nbnd40/out"
 nbnd = 40
 
+# -----------------------------------------------------------------------------
+# Interaction (THC Coulomb)
+# -----------------------------------------------------------------------------
 [interaction.thc]
 thresh = 1e-5
 ecut = 60
 save = "thc.coulomb.h5"
 
-[gw]
-output = "svo"
+# -----------------------------------------------------------------------------
+# GW+EDMFT
+# -----------------------------------------------------------------------------
+[gw_edmft]
 restart = true
-screen_type = "gw_edmft_density"
-niter = 1
-div_treatment = "gygi_extrplt"
-[gw.iter_alg]
+outdir = "./"
+prefix = "svo"
+
+niter = 1               # Number of GW+EDMFT cycles
+gw_iter_per_loop = 1    # Number of GW updates per outer cycle
+edmft_iter_per_loop = 1 # Number of EDMFT updates per outer cycle
+
+screen_type = "gw_edmft_density"     # Screening model: gw_edmft or rpa
+div_treatment = "gygi_metal_order_3" # q->0 divergence treatment
+
+corr_only = true # Embed only the dynamic self-energy part
+
+# GW loop mixing
+[gw_edmft.gw.iter_alg]
 alg = "damping"
-mixing = 0.2
+mixing = 0.15
 
-[wloc]
-outdir = "./"
-prefix = "svo"
-screen_type = "gw_edmft_density"
-div_treatment = "gygi_extrplt"
+# -----------------------------------------------------------------------------
+# EDMFT controls
+# -----------------------------------------------------------------------------
+[gw_edmft.edmft]
+chkpt_h5 = "svo.dmft.h5" # Default would be: {outdir}/{prefix}.mbpt.h5
+dlr_wmax = 5              # DLR frequency cutoff for EDMFT subspaces
+dlr_eps = 1e-10           # DLR target precision for EDMFT subspaces
 
-[gloc]
-outdir = "./"
-prefix = "svo"
+# EDFMT loop mixing
+[gw_edmft.edmft.iter_alg]
+alg = "damping"
+mixing = 0.15
 
-[dmft_embed]
-outdir = "./"
-prefix = "svo"
-corr_only = true
+# -----------------------------------------------------------------------------
+# Impurity solver block
+# Add multiple [[gw_edmft.edmft.impurity]] sections for multiple impurities.
+# -----------------------------------------------------------------------------
+[[gw_edmft.edmft.impurity]]
+screen_j = false                  # Add screening contribution to J
+init_imp_results = "dc"           # Initial impurity self-energy/polarization: dc or zero
+degenerate_blk = [[0, 1, 2, 3, 4, 5]]
 
-[impurity]
-chkpt_h5 = "svo.dmft.h5"   # checkpoint h5 for dmft results
-restart  = true
-dlr_wmax = 5
-dlr_eps  = 1e-10
-
-[[impurity.solver]]
-init_weiss_type = 'dc'
-degenerate_blk = [[0,1,2,3,4,5]]    
 n_iw = 3000
 n_tau = 96001
 length_cycle = 60
-n_warmup_cycles = 5000
+n_warmup_cycles = 6000
 n_cycles = 2000000
+
 measure_pert_order = true
 perform_tail_fit = true
+analytic_hf = true
 fit_max_moment = 12
 fit_min_w = 1.8
 fit_max_w = 4.5
 
-[impurity.solver.chemical_potential] 
-verbosity       = true
-tolerance       = 0.1 
-length_cycle    = 40
+# Impurity chemical potential solver
+[gw_edmft.edmft.impurity.chemical_potential]
+verbosity = true
+tolerance = 0.1
+length_cycle = 60
 n_warmup_cycles = 1000
-n_cycles        = 100000
+n_cycles = 100000
 
-[impurity.iter_alg]
-alg = "damping"
-mixing = 0.2
+# Optional regularization / causality projection controls
+[gw_edmft.edmft.impurity.causal_projection]
+exclude_w0 = false
+w0_treatment_for_pi = "extrapolate_order_2"
+# w0_treatment_for_w = "flatten"
+# w0_treatment_for_weiss = "flatten"
+nbath_per_orbital = -1

--- a/src/hamiltonian/tests/test_hamilt.cpp
+++ b/src/hamiltonian/tests/test_hamilt.cpp
@@ -333,7 +333,7 @@ void check_K(mpi_context_t& mpi, std::shared_ptr<mf::MF> &mfobj, double x) {
     methods::thc_reader_t thc(mfobj,
                               methods::make_thc_reader_ptree(0.0, "", "incore", "test.h5", "bdft",
                                                              1e-8, mfobj->ecutrho(), 1, 1024));
-    methods::solvers::hf_t hf(methods::ignore_g0);
+    methods::solvers::hf_t hf("ignore_g0");
 
     auto sS_skij = make_shared_array<array_view_4d_t>(
         mpi.comm, mpi.internode_comm, mpi.node_comm, {nspin, nkpts_ibz, nbnd, nbnd});

--- a/src/methods/ERI/div_treatment_e.hpp
+++ b/src/methods/ERI/div_treatment_e.hpp
@@ -22,68 +22,7 @@
 #ifndef METHODS_ERI_DIV_TREATMENT_HPP
 #define METHODS_ERI_DIV_TREATMENT_HPP
 
-namespace methods
-{
-
-enum div_treatment_e {
-  ignore_g0, gygi, gygi_average, 
-  gygi_linear, gygi_linear_metal, 
-  gygi_linear_2d, gygi_linear_metal_2d,
-  gygi_extrplt, gygi_extrplt_2d
-};
-
-inline std::string div_enum_to_string(int div_enum) {
-  switch(div_enum) {
-    case div_treatment_e::ignore_g0:
-      return "ignore_g0";
-    case div_treatment_e::gygi:
-      return "gygi";
-    case div_treatment_e::gygi_average:
-      return "gygi_average";
-    case div_treatment_e::gygi_linear:
-      return "gygi_linear";
-    case div_treatment_e::gygi_linear_metal:
-      return "gygi_linear_metal";
-    case div_treatment_e::gygi_linear_metal_2d:
-      return "gygi_linear_metal_2d";
-    case div_treatment_e::gygi_linear_2d:
-      return "gygi_linear_2d";
-    case div_treatment_e::gygi_extrplt:
-      return "gygi_extrplt";
-    case div_treatment_e::gygi_extrplt_2d:
-      return "gygi_extrplt_2d";
-    default:
-      return "not recognized...";
-  }
-}
-
-inline div_treatment_e string_to_div_enum(std::string div_name) {
-  if (div_name == "ignore_g0") {
-    return div_treatment_e::ignore_g0;
-  } else if (div_name == "gygi") {
-    return div_treatment_e::gygi;
-  } else if (div_name == "gygi_average") {
-    return div_treatment_e::gygi_average;
-  } else if (div_name == "gygi_linear") {
-    return div_treatment_e::gygi_linear;
-  } else if (div_name == "gygi_linear_metal") {
-    return div_treatment_e::gygi_linear_metal;
-  } else if (div_name == "gygi_linear_2d") {
-    return div_treatment_e::gygi_linear_2d;
-  } else if (div_name == "gygi_linear_metal_2d") {
-    return div_treatment_e::gygi_linear_metal_2d;
-  } else if (div_name == "gygi_extrplt") {
-    return div_treatment_e::gygi_extrplt;
-  } else if (div_name == "gygi_extrplt_2d") {
-    return div_treatment_e::gygi_extrplt_2d;
-  } else {
-    utils::check(false, "Unrecognized divergence treatment: {}. "
-                        "Available options: ignore_g0, gygi, gygi_extrplt, gygi_extrplt_2d \n",
-                        "(The option \"ewald\" is now renamed to \"gygi\")", div_name);
-    return div_treatment_e::gygi;
-  }
-}
-
-}
+// Deprecated header intentionally left empty.
+// Divergence treatments are plain std::string values now.
 
 #endif // METHODS_ERI_DIV_TREATMENT_HPP

--- a/src/methods/ERI/div_treatment_e.hpp
+++ b/src/methods/ERI/div_treatment_e.hpp
@@ -26,7 +26,10 @@ namespace methods
 {
 
 enum div_treatment_e {
-  ignore_g0, gygi, gygi_average, gygi_linear, gygi_linear_2d, gygi_extrplt, gygi_extrplt_2d
+  ignore_g0, gygi, gygi_average, 
+  gygi_linear, gygi_linear_metal, 
+  gygi_linear_2d, gygi_linear_metal_2d,
+  gygi_extrplt, gygi_extrplt_2d
 };
 
 inline std::string div_enum_to_string(int div_enum) {
@@ -39,6 +42,10 @@ inline std::string div_enum_to_string(int div_enum) {
       return "gygi_average";
     case div_treatment_e::gygi_linear:
       return "gygi_linear";
+    case div_treatment_e::gygi_linear_metal:
+      return "gygi_linear_metal";
+    case div_treatment_e::gygi_linear_metal_2d:
+      return "gygi_linear_metal_2d";
     case div_treatment_e::gygi_linear_2d:
       return "gygi_linear_2d";
     case div_treatment_e::gygi_extrplt:
@@ -59,8 +66,12 @@ inline div_treatment_e string_to_div_enum(std::string div_name) {
     return div_treatment_e::gygi_average;
   } else if (div_name == "gygi_linear") {
     return div_treatment_e::gygi_linear;
+  } else if (div_name == "gygi_linear_metal") {
+    return div_treatment_e::gygi_linear_metal;
   } else if (div_name == "gygi_linear_2d") {
     return div_treatment_e::gygi_linear_2d;
+  } else if (div_name == "gygi_linear_metal_2d") {
+    return div_treatment_e::gygi_linear_metal_2d;
   } else if (div_name == "gygi_extrplt") {
     return div_treatment_e::gygi_extrplt;
   } else if (div_name == "gygi_extrplt_2d") {

--- a/src/methods/ERI/div_treatment_e.hpp
+++ b/src/methods/ERI/div_treatment_e.hpp
@@ -26,7 +26,7 @@ namespace methods
 {
 
 enum div_treatment_e {
-  ignore_g0, gygi, gygi_extrplt, gygi_extrplt_2d
+  ignore_g0, gygi, gygi_average, gygi_linear, gygi_linear_2d, gygi_extrplt, gygi_extrplt_2d
 };
 
 inline std::string div_enum_to_string(int div_enum) {
@@ -35,6 +35,12 @@ inline std::string div_enum_to_string(int div_enum) {
       return "ignore_g0";
     case div_treatment_e::gygi:
       return "gygi";
+    case div_treatment_e::gygi_average:
+      return "gygi_average";
+    case div_treatment_e::gygi_linear:
+      return "gygi_linear";
+    case div_treatment_e::gygi_linear_2d:
+      return "gygi_linear_2d";
     case div_treatment_e::gygi_extrplt:
       return "gygi_extrplt";
     case div_treatment_e::gygi_extrplt_2d:
@@ -49,6 +55,12 @@ inline div_treatment_e string_to_div_enum(std::string div_name) {
     return div_treatment_e::ignore_g0;
   } else if (div_name == "gygi") {
     return div_treatment_e::gygi;
+  } else if (div_name == "gygi_average") {
+    return div_treatment_e::gygi_average;
+  } else if (div_name == "gygi_linear") {
+    return div_treatment_e::gygi_linear;
+  } else if (div_name == "gygi_linear_2d") {
+    return div_treatment_e::gygi_linear_2d;
   } else if (div_name == "gygi_extrplt") {
     return div_treatment_e::gygi_extrplt;
   } else if (div_name == "gygi_extrplt_2d") {

--- a/src/methods/GF2/gf2_t.cpp
+++ b/src/methods/GF2/gf2_t.cpp
@@ -37,14 +37,13 @@
 #include "methods/ERI/chol_reader_t.hpp"
 #include "methods/ERI/thc_reader_t.hpp"
 #include "methods/ERI/detail/concepts.hpp"
-#include "methods/ERI/div_treatment_e.hpp"
 
 #include "methods/GF2/gf2_t.h"
 
 namespace methods::solvers {
 
   gf2_t::gf2_t(mf::MF *MF, imag_axes_ft::IAFT *ft,
-       div_treatment_e div, 
+      std::string div, 
        std::string direct_type,
        std::string exchange_alg,
        std::string exchange_type,
@@ -77,7 +76,7 @@ namespace methods::solvers {
                "    exchange_type = {}\n"
                "    exchange_alg = {}\n"
                "    t_thresh = {}\n",
-            _MF->nbnd(), thc.Np(), _MF->nkpts(), _MF->nkpts_ibz(), div_enum_to_string(_div_treatment),
+            _MF->nbnd(), thc.Np(), _MF->nkpts(), _MF->nkpts_ibz(), _div_treatment,
             _direct_type, _exchange_type, _exchange_alg, _t_thresh);
     _ft->metadata_log();
 
@@ -286,7 +285,7 @@ namespace methods::solvers {
 
   long& gf2_t::iter() { return _iter; }
   std::string gf2_t::output() const { return _output; }
-  div_treatment_e gf2_t::gw_div_treatment() const { return _div_treatment; }
+  std::string gf2_t::gw_div_treatment() const { return _div_treatment; }
   double& gf2_t::t_thresh() { return _t_thresh; }
 
   std::string gf2_t::direct_type() const {return _direct_type; }

--- a/src/methods/GF2/gf2_t.h
+++ b/src/methods/GF2/gf2_t.h
@@ -36,7 +36,6 @@
 #include "numerics/imag_axes_ft/IAFT.hpp"
 #include "methods/scr_coulomb/scr_coulomb_t.h"
 #include "methods/ERI/detail/concepts.hpp"
-#include "methods/ERI/div_treatment_e.hpp"
 
 #define W_GATHER_OLD 0 // a switch to the old version for debugging
 
@@ -83,7 +82,7 @@ namespace methods {
 
     public:
       gf2_t(mf::MF *MF, imag_axes_ft::IAFT *ft,
-           div_treatment_e div = gygi, 
+           std::string div = "gygi", 
            std::string direct_type="gf2",
            std::string exchange_alg="orb",
            std::string exchange_type="gf2",
@@ -116,7 +115,7 @@ namespace methods {
       // accessor functions
       long& iter(); 
       std::string output() const;
-      div_treatment_e gw_div_treatment() const;
+      std::string gw_div_treatment() const;
       double& t_thresh(); 
 
       std::string direct_type() const; 
@@ -722,7 +721,7 @@ namespace methods {
       mf::MF *_MF = nullptr;
       imag_axes_ft::IAFT* _ft = nullptr;
 
-      div_treatment_e _div_treatment = div_treatment_e::ignore_g0;
+      std::string _div_treatment = "ignore_g0";
       double _t_thresh = 0.0; // it prescreening threshold
       std::string _direct_type = "gf2";
       std::string _exchange_type = "gf2";

--- a/src/methods/GF2/tests/test_thc_gf2.cpp
+++ b/src/methods/GF2/tests/test_thc_gf2.cpp
@@ -48,7 +48,7 @@ namespace bdft_tests {
     imag_axes_ft::IAFT ft(1000, 1.2, imag_axes_ft::ir_source);
     auto mf = std::make_shared<mf::MF>(mf::default_MF(mpi_context, "pyscf_h2_222"));
     solvers::hf_t hf;
-    solvers::gf2_t gf2(mf.get(), &ft, string_to_div_enum("gygi"),
+    solvers::gf2_t gf2(mf.get(), &ft, "gygi",
                        "gf2", "orb", "gf2", output);
 
     { // incore thc-gf2

--- a/src/methods/GF2/thc_gf2.icc
+++ b/src/methods/GF2/thc_gf2.icc
@@ -17,7 +17,6 @@
 #include "mean_field/MF.hpp"
 #include "methods/ERI/detail/concepts.hpp"
 #include "methods/HF/thc_solver_comm.hpp"
-#include "methods/ERI/div_treatment_e.hpp"
 
 
 namespace methods {
@@ -150,7 +149,7 @@ namespace methods {
         dUPiU_tqPQ.reset();
 
         _Timer.start("EVALUATE_SIGMA_DIR");
-        gw_t gw(_ft, ignore_g0, _output);
+        gw_t gw(_ft, "ignore_g0", _output);
         gw.eval_Sigma_all(G_tskij, dUPiU_qtPQ, sSigma_tskij, thc, "R");
         _Timer.stop("EVALUATE_SIGMA_DIR");
 

--- a/src/methods/GF2/thc_sosex.icc
+++ b/src/methods/GF2/thc_sosex.icc
@@ -17,7 +17,6 @@
 #include "mean_field/MF.hpp"
 #include "methods/ERI/detail/concepts.hpp"
 #include "methods/HF/thc_solver_comm.hpp"
-#include "methods/ERI/div_treatment_e.hpp"
 
 #define W_CACHED 1
 

--- a/src/methods/GW/g0_div_utils.hpp
+++ b/src/methods/GW/g0_div_utils.hpp
@@ -89,6 +89,7 @@ namespace methods {
         }
 
         if (div_treatment.find("gygi_extrplt") != std::string::npos) {
+          // TODO Deprecated method. Should be removed in the future. 
           utils::check(mf.nkpts_ibz() > 1, "extrapolate_eps_inv_q0: nkpts_ibz <= 1 while div_treatment==gygi_extrplt");
           
           auto q_indices = filter_qpts(mf.Qpts_ibz(), 0.8, 1, two_dimension);
@@ -99,8 +100,12 @@ namespace methods {
             Q_filtered(i) = Q_abs( q_indices[i] );
             eps_inv_filtered(nda::range::all, i) = eps_inv_wq(nda::range::all, q_indices[i] );
           }
-          
-          if ( q_indices.size() < 3) {
+
+          if ( q_indices.empty() ) {
+            // If no q-points passed the filter, fall back to the smallest-|q| point
+            int smallest_idx = find_smallest_qabs(mf.Qpts_ibz(), false);
+            eps_inv_q0_w = eps_inv_wq(nda::range::all, smallest_idx);
+          } else if ( q_indices.size() < 3) {
             // Choose the closest point to the gamma instead
             eps_inv_q0_w = eps_inv_wq(nda::range::all, q_indices[0]);
           } else {
@@ -157,19 +162,20 @@ namespace methods {
             }
           }
 
-          auto closest_indices = find_n_closest_per_direction(mf.Qpts_ibz(), mf.recv(), fit_order+1);
+          auto closest_indices = find_n_closest_per_direction(mf.Qpts_ibz(), mf.lattv(), fit_order+1);
 
           if (two_dimension)
             app_log(2, "\n Polynomial extrapolate head of the inverse of the dielectric function as O(q^2)\n"
-                       " up to order {}using the closest {} points along b1 and b2 directions", fit_order, fit_order+1);
+                       " up to order {} using the closest {} points along +/-b1, and +/-b2 directions", fit_order, fit_order+1);
           else
             app_log(2, "\n Polynomial extrapolate head of the inverse of the dielectric function as O(q^2)\n"
-                       " up to order {} using the closest {} points along b1, b2, and b3 directions", fit_order, fit_order+1);
+                       " up to order {} using the closest {} points along +/-b1, +/-b2, and +/-b3 directions", fit_order, fit_order+1);
           
           int dim = 0;
-          for (int dir = 0; dir < 3; ++dir) {
+          constexpr std::array<const char *, 6> direction_labels = {"+b1", "-b1", "+b2", "-b2", "+b3", "-b3"};
+          for (int dir = 0; dir < 6; ++dir) {
 
-            if (two_dimension and dir == 2) continue; // skip b3 direction for 2D materials
+            if (two_dimension and dir >= 4) continue; // skip b3 directions for 2D materials
 
             nda::array<ComplexType, 1> Q_filtered(closest_indices[dir].size());
             nda::array<ComplexType, 2> eps_inv_filtered(niw, closest_indices[dir].size());
@@ -183,7 +189,7 @@ namespace methods {
               continue; // no point found along this direction, skip extrapolation
             }
             
-            app_log(2, "\n  Found {} points along b{} direction for extrapolation.", closest_indices[dir].size(), dir+1);
+            app_log(2, "\n  Found {} points along {} direction for extrapolation.", closest_indices[dir].size(), direction_labels[dir]);
 
             for (int n = 0; n < niw; ++n) {
               eps_inv_q0_w(n) += extrapolate_to_q0(
@@ -199,7 +205,7 @@ namespace methods {
           eps_inv_q0_w /= static_cast<double>(dim); // average over the number of dimensions extrapolated
 
           if (div_treatment.find("metal") != std::string::npos) {
-            app_log(2, "Enforcing the static limit of the inverse dielectric function to 0 for metallic systems.");
+            app_log(2, "\n Enforcing the static limit of the inverse dielectric function to 0 for metallic systems.\n");
             // for metals, set the static limit to -1 manually, i.e. inverse dielectric function goes to 0 at q=0 and w=0
             eps_inv_q0_w(0) = -1.0;
           }
@@ -291,7 +297,7 @@ namespace methods {
       /**
        * Extract the head (G=G'=0 component) of the inverse symmetric dielectric function at finite q
        * 
-       * Computes \epsilon^{q,-1}_{G=0,G'=0} from the screened interaction W(x,q,P,Q) in the THC product basis.
+       * Computes \epsilon^{q,-1}_{G=0,G'=0} - 1 from the screened interaction W(x,q,P,Q) in the THC product basis.
        * Works for W on both imaginary-time and Matsubara frequency axes.
        * 
        * @param dW_xqPQ    - [INPUT] screened interaction in the THC product basis
@@ -313,6 +319,7 @@ namespace methods {
         auto [nx, nqpts_ibz, NP, NQ] = dW_xqPQ.global_shape();
 
         nda::array<ComplexType, 2> eps_inv_x(nx, nqpts_ibz);
+        eps_inv_x() = 0.0;
         nda::array<ComplexType, 1> Chi_bar_Q_conj(NQ_loc);
         nda::array<ComplexType, 1> buffer_P(NP_loc);
         const double fpi = 4.0*3.14159265358979323846;
@@ -383,36 +390,37 @@ namespace methods {
       }
 
       /**
-       * Find up to n closest points to origin along each Cartesian direction
-       * For a uniform 3D grid centered at origin spanning [-0.5, 0.5] in each direction,
-       * this function finds points with smallest positive coordinate values
-       * along x, y, and z directions. Only searches on the positive side (accounting for symmetry).
+       * Find up to n closest points to origin along each signed Cartesian direction
+       * For a uniform 3D grid centered at origin spanning (-0.5, 0.5] in each direction,
+       * this function finds points with smallest coordinate magnitudes along
+       * +b1, -b1, +b2, -b2, +b3, and -b3 directions.
        * @param Qpts      - [INPUT] array of q-points (shape: [nqpts, 3])
-       * @param recv      - [INPUT] reciprocal lattice vectors (shape: [3, 3])
+       * @param lattv     - [INPUT] lattice vectors (shape: [3, 3])
        * @param n         - [INPUT] number of closest points (at maximum) to return per direction
        * @param tolerance - [INPUT] threshold to consider a coordinate as zero (default: 1e-10)
-       * @return array of 3 vectors containing indices for x, y, z directions respectively
+       * @return array of 6 vectors containing indices for +b1, -b1, +b2, -b2, +b3, -b3 directions respectively
        */
-      template<nda::ArrayOfRank<2> Array_2D_t, nda::ArrayOfRank<2> Array_2D_recv_t>
-      static std::array<std::vector<int>, 3> find_n_closest_per_direction(
-        Array_2D_t &&Qpts, Array_2D_recv_t &&recv, int n, double tolerance=1e-10) {
+      template<nda::ArrayOfRank<2> Array_2D_t, nda::ArrayOfRank<2> Array_2D_latt_t>
+      static std::array<std::vector<int>, 6> find_n_closest_per_direction(
+        Array_2D_t &&Qpts, Array_2D_latt_t &&lattv, int n, double tolerance=1e-10) {
 
         utils::check(n > 0, "g0_div_utils.hpp::find_n_closest_per_direction: n must be positive");
 
-        if (Qpts.shape(0) == 1) return {{{0}, {0}, {0}}};
+        if (Qpts.shape(0) == 1) return {{{0}, {0}, {0}, {0}, {0}, {0}}};
         
-        // Convert to crystal coordinates using the reciprocal lattice vectors
+        // Convert to crystal coordinates using the lattice vectors
         nda::array<double, 2> Qpts_crys(Qpts.shape(0), 3);
         for (int iq = 0; iq < Qpts.shape(0); ++iq) {
-          nda::blas::gemv(1.0, recv, Qpts(iq,nda::range::all), 0.0, Qpts_crys(iq,nda::range::all));
+          double tpiinv = 1.0 / (2.0 * 3.14159265358979); 
+          nda::blas::gemv(tpiinv, lattv, Qpts(iq,nda::range::all), 0.0, Qpts_crys(iq,nda::range::all));
         }
         
-        std::array<std::vector<int>, 3> result_indices;
+        std::array<std::vector<int>, 6> result_indices;
         
-        // For each direction (x=0, y=1, z=2)
+        // For each Cartesian axis, collect the closest points on the positive and negative sides separately.
         for (int dir = 0; dir < 3; ++dir) {
-          // Collect all positive values in this direction with their indices
-          std::vector<std::pair<double, int>> coord_idx_pairs;
+          std::vector<std::pair<double, int>> positive_coord_idx_pairs;
+          std::vector<std::pair<double, int>> negative_coord_idx_pairs;
           
           for (int i = 0; i < Qpts_crys.shape(0); ++i) {
             double coord = Qpts_crys(i, dir);
@@ -426,19 +434,29 @@ namespace methods {
               }
             }
             
-            // Only consider positive coordinates with other dimensions zero
-            if (coord > tolerance && other_dims_zero) {
-              coord_idx_pairs.push_back({coord, i});
+            if (!other_dims_zero) continue;
+
+            // treat -0.5 as 0.5 due to periodicity
+            if (std::abs(coord + 0.5) < 1e-6) coord = std::abs(coord);
+
+            if (coord > tolerance) {
+              positive_coord_idx_pairs.push_back({coord, i});
+            } else if (coord < -tolerance) {
+              negative_coord_idx_pairs.push_back({std::abs(coord), i});
             }
           }
           
-          // Sort by coordinate value
-          std::sort(coord_idx_pairs.begin(), coord_idx_pairs.end());
-          
-          // Collect the n smallest (or fewer if not enough points)
-          int count = std::min(n, static_cast<int>(coord_idx_pairs.size()));
-          for (int j = 0; j < count; ++j) {
-            result_indices[dir].push_back(coord_idx_pairs[j].second);
+          std::sort(positive_coord_idx_pairs.begin(), positive_coord_idx_pairs.end());
+          std::sort(negative_coord_idx_pairs.begin(), negative_coord_idx_pairs.end());
+
+          int positive_count = std::min(n, static_cast<int>(positive_coord_idx_pairs.size()));
+          for (int j = 0; j < positive_count; ++j) {
+            result_indices[2 * dir].push_back(positive_coord_idx_pairs[j].second);
+          }
+
+          int negative_count = std::min(n, static_cast<int>(negative_coord_idx_pairs.size()));
+          for (int j = 0; j < negative_count; ++j) {
+            result_indices[2 * dir + 1].push_back(negative_coord_idx_pairs[j].second);
           }
         }
         

--- a/src/methods/GW/g0_div_utils.hpp
+++ b/src/methods/GW/g0_div_utils.hpp
@@ -78,6 +78,9 @@ namespace methods {
                                           div_treatment_e div_treatment=gygi_extrplt,
                                           bool poly_in_q2=false, double q_max=0.8, int fit_order=2)
       -> nda::array<ComplexType, 1> {
+
+        auto div_string = div_enum_to_string(div_treatment);
+        bool two_dimension = (div_string.find("2d") != std::string::npos)? true : false;
         
         auto [niw, nqpts_ibz] = eps_inv_wq.shape();
         nda::array<ComplexType, 1> eps_inv_q0_w(niw);
@@ -91,12 +94,11 @@ namespace methods {
           Q_abs(iq) = ComplexType( std::sqrt( qpt(0)*qpt(0) + qpt(1)*qpt(1) + qpt(2)*qpt(2) ) );
         }
 
-        if (div_treatment==gygi_extrplt or div_treatment==gygi_extrplt_2d) {
+        if (div_string.find("gygi_extrplt") != std::string::npos) {
           utils::check(mf.nkpts_ibz() > 1, "extrapolate_eps_inv_q0: nkpts_ibz <= 1 while div_treatment==gygi_extrplt");
-          bool two_dim = (div_treatment==gygi_extrplt_2d)? true : false;
           
-          auto q_indices = (poly_in_q2)? filter_qpts(mf.Qpts_ibz(), q_max, 2, two_dim)
-                           : filter_qpts(mf.Qpts_ibz(), q_max, 1, two_dim);
+          auto q_indices = (poly_in_q2)? filter_qpts(mf.Qpts_ibz(), q_max, 2, two_dimension)
+                           : filter_qpts(mf.Qpts_ibz(), q_max, 1, two_dimension);
           nda::array<ComplexType, 1> Q_filtered(q_indices.size());
           nda::array<ComplexType, 2> eps_inv_filtered(niw, q_indices.size());
           
@@ -109,7 +111,7 @@ namespace methods {
             // Choose the closest point to the gamma instead
             eps_inv_q0_w = eps_inv_wq(nda::range::all, q_indices[0]);
           } else {
-            if (two_dim)
+            if (two_dimension)
               app_log(2, "  Extrapolate head of the inverse of the dielectric function from {} q-points on the xy-plane", q_indices.size());
             else
               app_log(2, "  Extrapolate head of the inverse of the dielectric function from {} q-points", q_indices.size());
@@ -119,12 +121,11 @@ namespace methods {
                                                   (n==0)? true : false);
             }
           }
-        } else if (div_treatment==gygi_linear or div_treatment==gygi_linear_2d) {
+        } else if (div_string.find("gygi_linear") != std::string::npos) {
           // Linear extrapolation to q=0 as A + B*q^2 using the two closest q-points to Gamma
           auto closest_two_indices = find_two_closest_per_direction(mf.Qpts_ibz(), mf.recv());
           
-          bool two_dim = (div_treatment==gygi_linear_2d)? true : false;
-          if (two_dim)
+          if (two_dimension)
             app_log(2, "  Linear extrapolate head of the inverse of the dielectric function (A + B*q^2)\n"
                        "  using the closet two points along b1 and b2 directions");
           else
@@ -134,7 +135,7 @@ namespace methods {
           int dim = 0;
           for (int dir = 0; dir < 3; ++dir) {
             
-            if (two_dim and dir == 2) continue; // skip b3 direction for 2D materials
+            if (two_dimension and dir == 2) continue; // skip b3 direction for 2D materials
             
             nda::array<ComplexType, 1> Q_filtered(closest_two_indices[dir].size());
             nda::array<ComplexType, 2> eps_inv_filtered(niw, closest_two_indices[dir].size());
@@ -162,7 +163,13 @@ namespace methods {
           utils::check(dim > 0, "extrapolate_eps_inv_q0: no valid q-point found for extrapolation in any direction");
           eps_inv_q0_w /= static_cast<double>(dim); // average over the number of dimensions extrapolated
 
-        } else if (div_treatment==gygi_average) {
+          if (div_string.find("metal") != std::string::npos) {
+            app_log(2, "Enforcing the static limit of the inverse dielectric function to 0 for metallic systems.");
+            // for metals, set the static limit to -1 manually, i.e. inverse dielectric function goes to 0 at q=0 and w=0
+            eps_inv_q0_w(0) = -1.0;
+          }
+
+        } else if (div_string.find("gygi_average") != std::string::npos) {
           // Average over all q-points with smallest |q|
           auto smallest_indices = find_smallest_qabs_indices(mf.Qpts_ibz(), false, false);
           eps_inv_q0_w = 0.0;
@@ -241,7 +248,6 @@ namespace methods {
 
         // Compute the head (i.e. G=G'=0 component) of the inverse dielectric function at finite q
         auto eps_inv_w = eval_eps_inv_q(dW_wqPQ, thc, mf);
-        auto [nw, nqpts_ibz] = eps_inv_w.shape();
 
         if (thc.MF()->nqpts_ibz() == 1 and div_treatment != ignore_g0) {
           app_log(2, "eps_inv_head_w: nqpts_ibz == 1 while div_treatment != ignore. "

--- a/src/methods/GW/g0_div_utils.hpp
+++ b/src/methods/GW/g0_div_utils.hpp
@@ -34,7 +34,6 @@
 
 #include "numerics/imag_axes_ft/IAFT.hpp"
 #include "methods/ERI/detail/concepts.hpp"
-#include "methods/ERI/div_treatment_e.hpp"
 #include "mean_field/MF.hpp"
 
 namespace methods {
@@ -67,20 +66,15 @@ namespace methods {
        * @param eps_inv_wq    - [INPUT] inverse dielectric function on frequency axis, shape [niw, nqpts_ibz]
        * @param mf            - [INPUT] mean-field object
        * @param div_treatment - [INPUT] divergence treatment method
-       * @param poly_in_q2    - [INPUT] whether to use polynomial in q^2 (default: false)
-       * @param q_max         - [INPUT] maximum q magnitude for filtering (default: 0.8)
-       * @param fit_order     - [INPUT] polynomial fit order (default: 2)
        * @return - inverse dielectric function at q=0, shape [niw]
        */
       template<nda::ArrayOfRank<2> Array_axis_t>
       static auto extrapolate_eps_inv_q0(const Array_axis_t &eps_inv_wq,
                                           mf::MF &mf,
-                                          div_treatment_e div_treatment=gygi_extrplt,
-                                          bool poly_in_q2=false, double q_max=0.8, int fit_order=2)
+                                          std::string div_treatment="gygi")
       -> nda::array<ComplexType, 1> {
 
-        auto div_string = div_enum_to_string(div_treatment);
-        bool two_dimension = (div_string.find("2d") != std::string::npos)? true : false;
+        bool two_dimension = (div_treatment.find("2d") != std::string::npos)? true : false;
         
         auto [niw, nqpts_ibz] = eps_inv_wq.shape();
         nda::array<ComplexType, 1> eps_inv_q0_w(niw);
@@ -94,16 +88,15 @@ namespace methods {
           Q_abs(iq) = ComplexType( std::sqrt( qpt(0)*qpt(0) + qpt(1)*qpt(1) + qpt(2)*qpt(2) ) );
         }
 
-        if (div_string.find("gygi_extrplt") != std::string::npos) {
+        if (div_treatment.find("gygi_extrplt") != std::string::npos) {
           utils::check(mf.nkpts_ibz() > 1, "extrapolate_eps_inv_q0: nkpts_ibz <= 1 while div_treatment==gygi_extrplt");
           
-          auto q_indices = (poly_in_q2)? filter_qpts(mf.Qpts_ibz(), q_max, 2, two_dimension)
-                           : filter_qpts(mf.Qpts_ibz(), q_max, 1, two_dimension);
+          auto q_indices = filter_qpts(mf.Qpts_ibz(), 0.8, 1, two_dimension);
           nda::array<ComplexType, 1> Q_filtered(q_indices.size());
           nda::array<ComplexType, 2> eps_inv_filtered(niw, q_indices.size());
           
           for (size_t i = 0; i < q_indices.size(); ++i) {
-            Q_filtered(i) = (poly_in_q2)? Q_abs2( q_indices[i] ) : Q_abs( q_indices[i] );
+            Q_filtered(i) = Q_abs( q_indices[i] );
             eps_inv_filtered(nda::range::all, i) = eps_inv_wq(nda::range::all, q_indices[i] );
           }
           
@@ -117,59 +110,13 @@ namespace methods {
               app_log(2, "  Extrapolate head of the inverse of the dielectric function from {} q-points", q_indices.size());
             
             for (int n = 0; n < niw; ++n) {
-              eps_inv_q0_w(n) = extrapolate_to_q0(Q_filtered, eps_inv_filtered(n, nda::range::all), fit_order,
+              eps_inv_q0_w(n) = extrapolate_to_q0(Q_filtered, eps_inv_filtered(n, nda::range::all), 2,
                                                   (n==0)? true : false);
             }
           }
-        } else if (div_string.find("gygi_linear") != std::string::npos) {
-          // Linear extrapolation to q=0 as A + B*q^2 using the two closest q-points to Gamma
-          auto closest_two_indices = find_two_closest_per_direction(mf.Qpts_ibz(), mf.recv());
-          
-          if (two_dimension)
-            app_log(2, "  Linear extrapolate head of the inverse of the dielectric function (A + B*q^2)\n"
-                       "  using the closet two points along b1 and b2 directions");
-          else
-            app_log(2, "  Linear extrapolate head of the inverse of the dielectric function (A + B*q^2)\n"
-                       "  using the closet two points along b1, b2, and b3 directions");
-          
-          int dim = 0;
-          for (int dir = 0; dir < 3; ++dir) {
-            
-            if (two_dimension and dir == 2) continue; // skip b3 direction for 2D materials
-            
-            nda::array<ComplexType, 1> Q_filtered(closest_two_indices[dir].size());
-            nda::array<ComplexType, 2> eps_inv_filtered(niw, closest_two_indices[dir].size());
-            
-            for (size_t i = 0; i < closest_two_indices[dir].size(); ++i) {
-              Q_filtered(i) = Q_abs2( closest_two_indices[dir][i] );
-              eps_inv_filtered(nda::range::all, i) = eps_inv_wq(nda::range::all, closest_two_indices[dir][i] );
-            }
-            
-            if (closest_two_indices[dir].size() == 0) {
-              continue; // no point found along this direction, skip extrapolation
-            } else if (closest_two_indices[dir].size() == 1) {
-              // Choose the closest point to the gamma instead of linear extrapolation
-              app_log(2, "Only found {} point along b{} direction --> use it directly without extrapolation.", 
-                      closest_two_indices[dir].size(), dir+1);
-              eps_inv_q0_w += eps_inv_filtered(nda::range::all, 0);
-            } else {
-              for (int n = 0; n < niw; ++n) {
-                eps_inv_q0_w(n) += extrapolate_to_q0(Q_filtered, eps_inv_filtered(n, nda::range::all), 1,
-                                                     (n==0)? true : false);
-              }
-            }
-            dim += 1;
-          }
-          utils::check(dim > 0, "extrapolate_eps_inv_q0: no valid q-point found for extrapolation in any direction");
-          eps_inv_q0_w /= static_cast<double>(dim); // average over the number of dimensions extrapolated
 
-          if (div_string.find("metal") != std::string::npos) {
-            app_log(2, "Enforcing the static limit of the inverse dielectric function to 0 for metallic systems.");
-            // for metals, set the static limit to -1 manually, i.e. inverse dielectric function goes to 0 at q=0 and w=0
-            eps_inv_q0_w(0) = -1.0;
-          }
+        } else if (div_treatment.find("gygi_average") != std::string::npos) {
 
-        } else if (div_string.find("gygi_average") != std::string::npos) {
           // Average over all q-points with smallest |q|
           auto smallest_indices = find_smallest_qabs_indices(mf.Qpts_ibz(), false, false);
           eps_inv_q0_w = 0.0;
@@ -177,9 +124,90 @@ namespace methods {
             eps_inv_q0_w += eps_inv_wq(nda::range::all, idx);
           }
           eps_inv_q0_w /= smallest_indices.size();
-        } else {
+
+        } else if (div_treatment.find("gygi_smallest_q") != std::string::npos or div_treatment == "ignore_g0") {
+
+          // Approximate q=0 value using the q-point closest to the Gamma point
+          // This is the old "gygi" method. 
           int smallest_idx = find_smallest_qabs(mf.Qpts_ibz(), false);
           eps_inv_q0_w = eps_inv_wq(nda::range::all, smallest_idx);
+
+        } else if (div_treatment.find("gygi") != std::string::npos) {
+
+          app_log(1, "");
+          app_log(1, "╔═══════════════════════════════════════════════════════════════════════════════════════════╗");
+          app_log(1, "║ [ NOTE ]                                                                                  ║");
+          app_log(1, "║ The 'gygi' treatment for the inverse dielectric function has been updated.                ║");
+          app_log(1, "║ The new 'gygi' method extrapolates to q=0 using a polynomial fit of the closest q-points. ║");
+          app_log(1, "║ This provides a more accurate estimate at q=0, important for treating finite-size effects.║");
+          app_log(1, "║                                                                                           ║");
+          app_log(1, "║ You can still access the previous 'gygi' treatment (uses smallest-|q| point) via          ║");
+          app_log(1, "║ 'gygi_smallest_q'. However, this older method is less accurate and not recommended.       ║");
+          app_log(1, "╚═══════════════════════════════════════════════════════════════════════════════════════════╝\n");
+
+          int fit_order = 2; // default
+          // Try to extract fit_order from string: "gygi_q2_fit_{N}[_...]"
+          const std::string order_prefix = "order_";
+          auto fit_pos = div_treatment.find(order_prefix);
+          if (fit_pos != std::string::npos) {
+            try {
+              fit_order = std::stoi(div_treatment.substr(fit_pos + order_prefix.size()));
+            } catch (...) {
+              // no numeric order suffix, keep default
+            }
+          }
+
+          auto closest_indices = find_n_closest_per_direction(mf.Qpts_ibz(), mf.recv(), fit_order+1);
+
+          if (two_dimension)
+            app_log(2, "\n Polynomial extrapolate head of the inverse of the dielectric function as O(q^2)\n"
+                       " up to order {}using the closest {} points along b1 and b2 directions", fit_order, fit_order+1);
+          else
+            app_log(2, "\n Polynomial extrapolate head of the inverse of the dielectric function as O(q^2)\n"
+                       " up to order {} using the closest {} points along b1, b2, and b3 directions", fit_order, fit_order+1);
+          
+          int dim = 0;
+          for (int dir = 0; dir < 3; ++dir) {
+
+            if (two_dimension and dir == 2) continue; // skip b3 direction for 2D materials
+
+            nda::array<ComplexType, 1> Q_filtered(closest_indices[dir].size());
+            nda::array<ComplexType, 2> eps_inv_filtered(niw, closest_indices[dir].size());
+            
+            for (size_t i = 0; i < closest_indices[dir].size(); ++i) {
+              Q_filtered(i) = Q_abs2( closest_indices[dir][i] );
+              eps_inv_filtered(nda::range::all, i) = eps_inv_wq(nda::range::all, closest_indices[dir][i] );
+            }
+
+            if (closest_indices[dir].size() == 0) {
+              continue; // no point found along this direction, skip extrapolation
+            }
+            
+            app_log(2, "\n  Found {} points along b{} direction for extrapolation.", closest_indices[dir].size(), dir+1);
+
+            for (int n = 0; n < niw; ++n) {
+              eps_inv_q0_w(n) += extrapolate_to_q0(
+                Q_filtered, eps_inv_filtered(n, nda::range::all), 
+                closest_indices[dir].size()-1, (n==0)? true : false
+              );
+            }
+
+            dim += 1;
+          }
+
+          utils::check(dim > 0, "extrapolate_eps_inv_q0: no valid q-point found for extrapolation in any direction");
+          eps_inv_q0_w /= static_cast<double>(dim); // average over the number of dimensions extrapolated
+
+          if (div_treatment.find("metal") != std::string::npos) {
+            app_log(2, "Enforcing the static limit of the inverse dielectric function to 0 for metallic systems.");
+            // for metals, set the static limit to -1 manually, i.e. inverse dielectric function goes to 0 at q=0 and w=0
+            eps_inv_q0_w(0) = -1.0;
+          }
+
+        } else {
+
+          utils::check(false, "extrapolate_eps_inv_q0: unrecognized div_treatment method: {}", div_treatment);
+
         }
 
         return eps_inv_q0_w;
@@ -198,18 +226,17 @@ namespace methods {
       template<nda::MemoryArrayOfRank<4> Array_w_t, THC_ERI thc_t, typename communicator_t>
       static auto eps_inv_head_t(memory::darray_t<Array_w_t, communicator_t> &dW_tqPQ, thc_t &thc,
                                  mf::MF &mf, const imag_axes_ft::IAFT *ft,
-                                 div_treatment_e div_treatment=gygi_extrplt,
-                                 bool poly_in_q2=false, double q_max=0.8, int fit_order=2)
+                                 std::string div_treatment="gygi")
       -> std::tuple<nda::array<ComplexType, 2>, nda::array<ComplexType, 1> > {
 
         // Compute the head (i.e. G=G'=0 component) of the inverse dielectric function at finite q
         auto eps_inv_t = eval_eps_inv_q(dW_tqPQ, thc, mf);
         auto [nts, nqpts_ibz] = eps_inv_t.shape();
 
-        if (thc.MF()->nqpts_ibz() == 1 and div_treatment != ignore_g0) {
+        if (thc.MF()->nqpts_ibz() == 1 and div_treatment != "ignore_g0") {
           app_log(2, "eps_inv_head_t: nqpts_ibz == 1 while div_treatment != ignore. "
                      "CoQui will take div_treatment = ignore_g0 anyway!");
-          div_treatment = ignore_g0;
+          div_treatment = "ignore_g0";
         }
 
         // Convert to Matsubara frequency axis for extrapolation
@@ -219,7 +246,7 @@ namespace methods {
 
         // Perform q=0 extrapolation on frequency domain data
         nda::array<ComplexType, 1> eps_inv_q0_w = 
-          extrapolate_eps_inv_q0(eps_inv_w, mf, div_treatment, poly_in_q2, q_max, fit_order);
+          extrapolate_eps_inv_q0(eps_inv_w, mf, div_treatment);
 
         // Convert result back to time domain
         nda::array<ComplexType, 1> eps_inv_q0_t(nts);
@@ -242,22 +269,21 @@ namespace methods {
        */
       template<nda::MemoryArrayOfRank<4> Array_w_t, THC_ERI thc_t, typename communicator_t>
       static auto eps_inv_head_w(memory::darray_t<Array_w_t, communicator_t> &dW_wqPQ, thc_t &thc,
-                                 mf::MF &mf, div_treatment_e div_treatment=gygi_extrplt,
-                                 bool poly_in_q2=false, double q_max=0.8, int fit_order=2)
+                                 mf::MF &mf, std::string div_treatment="gygi")
       -> std::tuple<nda::array<ComplexType, 2>, nda::array<ComplexType, 1> > {
 
         // Compute the head (i.e. G=G'=0 component) of the inverse dielectric function at finite q
         auto eps_inv_w = eval_eps_inv_q(dW_wqPQ, thc, mf);
 
-        if (thc.MF()->nqpts_ibz() == 1 and div_treatment != ignore_g0) {
+        if (thc.MF()->nqpts_ibz() == 1 and div_treatment != "ignore_g0") {
           app_log(2, "eps_inv_head_w: nqpts_ibz == 1 while div_treatment != ignore. "
                      "CoQui will take div_treatment = ignore_g0 anyway!");
-          div_treatment = ignore_g0;
+          div_treatment = "ignore_g0";
         }
 
         // Perform q=0 extrapolation on frequency domain data
         nda::array<ComplexType, 1> eps_inv_q0_w = 
-          extrapolate_eps_inv_q0(eps_inv_w, mf, div_treatment, poly_in_q2, q_max, fit_order);
+          extrapolate_eps_inv_q0(eps_inv_w, mf, div_treatment);
 
         return std::make_tuple(std::move(eps_inv_w), std::move(eps_inv_q0_w));
       }
@@ -357,18 +383,21 @@ namespace methods {
       }
 
       /**
-       * Find the two closest points to origin along each Cartesian direction
+       * Find up to n closest points to origin along each Cartesian direction
        * For a uniform 3D grid centered at origin spanning [-0.5, 0.5] in each direction,
-       * this function finds the two points with smallest positive coordinate values
+       * this function finds points with smallest positive coordinate values
        * along x, y, and z directions. Only searches on the positive side (accounting for symmetry).
        * @param Qpts      - [INPUT] array of q-points (shape: [nqpts, 3])
        * @param recv      - [INPUT] reciprocal lattice vectors (shape: [3, 3])
+       * @param n         - [INPUT] number of closest points (at maximum) to return per direction
        * @param tolerance - [INPUT] threshold to consider a coordinate as zero (default: 1e-10)
        * @return array of 3 vectors containing indices for x, y, z directions respectively
        */
       template<nda::ArrayOfRank<2> Array_2D_t, nda::ArrayOfRank<2> Array_2D_recv_t>
-      static std::array<std::vector<int>, 3> find_two_closest_per_direction(
-        Array_2D_t &&Qpts, Array_2D_recv_t &&recv, double tolerance=1e-10) {
+      static std::array<std::vector<int>, 3> find_n_closest_per_direction(
+        Array_2D_t &&Qpts, Array_2D_recv_t &&recv, int n, double tolerance=1e-10) {
+
+        utils::check(n > 0, "g0_div_utils.hpp::find_n_closest_per_direction: n must be positive");
 
         if (Qpts.shape(0) == 1) return {{{0}, {0}, {0}}};
         
@@ -406,8 +435,8 @@ namespace methods {
           // Sort by coordinate value
           std::sort(coord_idx_pairs.begin(), coord_idx_pairs.end());
           
-          // Collect the two smallest (or fewer if not enough points)
-          int count = std::min(2, static_cast<int>(coord_idx_pairs.size()));
+          // Collect the n smallest (or fewer if not enough points)
+          int count = std::min(n, static_cast<int>(coord_idx_pairs.size()));
           for (int j = 0; j < count; ++j) {
             result_indices[dir].push_back(coord_idx_pairs[j].second);
           }
@@ -490,10 +519,14 @@ namespace methods {
       }
 
       template<nda::ArrayOfRank<1> Array_q_t, nda::ArrayOfRank<1> Array_eps_t>
-      static auto extrapolate_to_q0(const Array_q_t &Qpts_abs2, const Array_eps_t &eps_inv_n, int fit_order,
+      static auto extrapolate_to_q0(const Array_q_t &Qpts_abs2, const Array_eps_t &eps_inv_q, int fit_order,
                                     bool print=false) {
 
         long num_sample = Qpts_abs2.shape(0);
+        if (num_sample == 1) {
+          return eps_inv_q(0);
+        }
+
         nda::matrix<ComplexType> A(num_sample, fit_order+1);
         for (int i = 0; i < num_sample; ++i) {
           A(i, 0) = 1.0;
@@ -504,7 +537,7 @@ namespace methods {
 
         auto AT = nda::make_regular(nda::transpose(A));
         nda::array<ComplexType, 1> AT_b(fit_order+1);
-        nda::blas::gemv(AT, eps_inv_n, AT_b);
+        nda::blas::gemv(AT, eps_inv_q, AT_b);
         nda::matrix<ComplexType> ATA_inv(fit_order+1, fit_order+1);
         nda::blas::gemm(AT, A, ATA_inv);
         ATA_inv = nda::inverse(ATA_inv);

--- a/src/methods/GW/g0_div_utils.hpp
+++ b/src/methods/GW/g0_div_utils.hpp
@@ -63,6 +63,122 @@ namespace methods {
       }
 
       /**
+       * Estimate the inverse of symmetric dielectric function at q=0.  
+       * @param eps_inv_wq    - [INPUT] inverse dielectric function on frequency axis, shape [niw, nqpts_ibz]
+       * @param mf            - [INPUT] mean-field object
+       * @param div_treatment - [INPUT] divergence treatment method
+       * @param poly_in_q2    - [INPUT] whether to use polynomial in q^2 (default: false)
+       * @param q_max         - [INPUT] maximum q magnitude for filtering (default: 0.8)
+       * @param fit_order     - [INPUT] polynomial fit order (default: 2)
+       * @return - inverse dielectric function at q=0, shape [niw]
+       */
+      template<nda::ArrayOfRank<2> Array_axis_t>
+      static auto extrapolate_eps_inv_q0(const Array_axis_t &eps_inv_wq,
+                                          mf::MF &mf,
+                                          div_treatment_e div_treatment=gygi_extrplt,
+                                          bool poly_in_q2=false, double q_max=0.8, int fit_order=2)
+      -> nda::array<ComplexType, 1> {
+        
+        auto [niw, nqpts_ibz] = eps_inv_wq.shape();
+        nda::array<ComplexType, 1> eps_inv_q0_w(niw);
+        eps_inv_q0_w() = 0.0;
+
+        nda::array<ComplexType, 1> Q_abs2(nqpts_ibz);
+        nda::array<ComplexType, 1> Q_abs(nqpts_ibz);
+        for (int iq = 0; iq < nqpts_ibz; ++iq) {
+          auto qpt = mf.Qpts_ibz(iq);
+          Q_abs2(iq) = ComplexType( qpt(0)*qpt(0) + qpt(1)*qpt(1) + qpt(2)*qpt(2) );
+          Q_abs(iq) = ComplexType( std::sqrt( qpt(0)*qpt(0) + qpt(1)*qpt(1) + qpt(2)*qpt(2) ) );
+        }
+
+        if (div_treatment==gygi_extrplt or div_treatment==gygi_extrplt_2d) {
+          utils::check(mf.nkpts_ibz() > 1, "extrapolate_eps_inv_q0: nkpts_ibz <= 1 while div_treatment==gygi_extrplt");
+          bool two_dim = (div_treatment==gygi_extrplt_2d)? true : false;
+          
+          auto q_indices = (poly_in_q2)? filter_qpts(mf.Qpts_ibz(), q_max, 2, two_dim)
+                           : filter_qpts(mf.Qpts_ibz(), q_max, 1, two_dim);
+          nda::array<ComplexType, 1> Q_filtered(q_indices.size());
+          nda::array<ComplexType, 2> eps_inv_filtered(niw, q_indices.size());
+          
+          for (size_t i = 0; i < q_indices.size(); ++i) {
+            Q_filtered(i) = (poly_in_q2)? Q_abs2( q_indices[i] ) : Q_abs( q_indices[i] );
+            eps_inv_filtered(nda::range::all, i) = eps_inv_wq(nda::range::all, q_indices[i] );
+          }
+          
+          if ( q_indices.size() < 3) {
+            // Choose the closest point to the gamma instead
+            eps_inv_q0_w = eps_inv_wq(nda::range::all, q_indices[0]);
+          } else {
+            if (two_dim)
+              app_log(2, "  Extrapolate head of the inverse of the dielectric function from {} q-points on the xy-plane", q_indices.size());
+            else
+              app_log(2, "  Extrapolate head of the inverse of the dielectric function from {} q-points", q_indices.size());
+            
+            for (int n = 0; n < niw; ++n) {
+              eps_inv_q0_w(n) = extrapolate_to_q0(Q_filtered, eps_inv_filtered(n, nda::range::all), fit_order,
+                                                  (n==0)? true : false);
+            }
+          }
+        } else if (div_treatment==gygi_linear or div_treatment==gygi_linear_2d) {
+          // Linear extrapolation to q=0 as A + B*q^2 using the two closest q-points to Gamma
+          auto closest_two_indices = find_two_closest_per_direction(mf.Qpts_ibz(), mf.recv());
+          
+          bool two_dim = (div_treatment==gygi_linear_2d)? true : false;
+          if (two_dim)
+            app_log(2, "  Linear extrapolate head of the inverse of the dielectric function (A + B*q^2)\n"
+                       "  using the closet two points along b1 and b2 directions");
+          else
+            app_log(2, "  Linear extrapolate head of the inverse of the dielectric function (A + B*q^2)\n"
+                       "  using the closet two points along b1, b2, and b3 directions");
+          
+          int dim = 0;
+          for (int dir = 0; dir < 3; ++dir) {
+            
+            if (two_dim and dir == 2) continue; // skip b3 direction for 2D materials
+            
+            nda::array<ComplexType, 1> Q_filtered(closest_two_indices[dir].size());
+            nda::array<ComplexType, 2> eps_inv_filtered(niw, closest_two_indices[dir].size());
+            
+            for (size_t i = 0; i < closest_two_indices[dir].size(); ++i) {
+              Q_filtered(i) = Q_abs2( closest_two_indices[dir][i] );
+              eps_inv_filtered(nda::range::all, i) = eps_inv_wq(nda::range::all, closest_two_indices[dir][i] );
+            }
+            
+            if (closest_two_indices[dir].size() == 0) {
+              continue; // no point found along this direction, skip extrapolation
+            } else if (closest_two_indices[dir].size() == 1) {
+              // Choose the closest point to the gamma instead of linear extrapolation
+              app_log(2, "Only found {} point along b{} direction --> use it directly without extrapolation.", 
+                      closest_two_indices[dir].size(), dir+1);
+              eps_inv_q0_w += eps_inv_filtered(nda::range::all, 0);
+            } else {
+              for (int n = 0; n < niw; ++n) {
+                eps_inv_q0_w(n) += extrapolate_to_q0(Q_filtered, eps_inv_filtered(n, nda::range::all), 1,
+                                                     (n==0)? true : false);
+              }
+            }
+            dim += 1;
+          }
+          utils::check(dim > 0, "extrapolate_eps_inv_q0: no valid q-point found for extrapolation in any direction");
+          eps_inv_q0_w /= static_cast<double>(dim); // average over the number of dimensions extrapolated
+
+        } else if (div_treatment==gygi_average) {
+          // Average over all q-points with smallest |q|
+          auto smallest_indices = find_smallest_qabs_indices(mf.Qpts_ibz(), false, false);
+          eps_inv_q0_w = 0.0;
+          for (int idx : smallest_indices) {
+            eps_inv_q0_w += eps_inv_wq(nda::range::all, idx);
+          }
+          eps_inv_q0_w /= smallest_indices.size();
+        } else {
+          int smallest_idx = find_smallest_qabs(mf.Qpts_ibz(), false);
+          eps_inv_q0_w = eps_inv_wq(nda::range::all, smallest_idx);
+        }
+
+        return eps_inv_q0_w;
+      }
+
+      /**
        * Estimate the inverse of symmetric dielectric function in plane-wave basis at G=G'=0
        * on the imaginary-time axis
        * @tparam extrapolate - perform extrapolation or not
@@ -79,54 +195,30 @@ namespace methods {
                                  bool poly_in_q2=false, double q_max=0.8, int fit_order=2)
       -> std::tuple<nda::array<ComplexType, 2>, nda::array<ComplexType, 1> > {
 
-        auto [eps_inv_t, Q_abs, Q_abs2] = eval_eps_inv_q(dW_tqPQ, thc, mf);
+        // Compute the head (i.e. G=G'=0 component) of the inverse dielectric function at finite q
+        auto eps_inv_t = eval_eps_inv_q(dW_tqPQ, thc, mf);
         auto [nts, nqpts_ibz] = eps_inv_t.shape();
 
         if (thc.MF()->nqpts_ibz() == 1 and div_treatment != ignore_g0) {
           app_log(2, "eps_inv_head_t: nqpts_ibz == 1 while div_treatment != ignore. "
-                     "Will take div_treatment = ignore_g0 anyway!");
+                     "CoQui will take div_treatment = ignore_g0 anyway!");
           div_treatment = ignore_g0;
         }
 
-        nda::array<ComplexType, 1> eps_inv_q0_t(nts);
-        if (div_treatment==gygi_extrplt or div_treatment==gygi_extrplt_2d) {
-          utils::check(mf.nkpts_ibz() > 1, "eps_inv_head_t: nkpts_ibz <= 1 while div_treatment==gygi_extrplt");
-          bool two_dim = (div_treatment==gygi_extrplt_2d)? true : false;
-          // extrapolation happens at frequency axis
-          long nw = (ft->nw_b()%2==0)? ft->nw_b()/2 : ft->nw_b()/2 + 1;
-          nda::array<ComplexType, 2> eps_inv_w(nw, nqpts_ibz);
-          ft->tau_to_w_PHsym(eps_inv_t, eps_inv_w);
+        // Convert to Matsubara frequency axis for extrapolation
+        long nw = (ft->nw_b()%2==0)? ft->nw_b()/2 : ft->nw_b()/2 + 1;
+        nda::array<ComplexType, 2> eps_inv_w(nw, nqpts_ibz);
+        ft->tau_to_w_PHsym(eps_inv_t, eps_inv_w);
 
-          auto q_indices = (poly_in_q2)? filter_qpts(mf.Qpts_ibz(), q_max, 2, two_dim)
-                           : filter_qpts(mf.Qpts_ibz(), q_max, 1, two_dim);
-          nda::array<ComplexType, 1> Q_filtered(q_indices.size());
-          nda::array<ComplexType, 2> eps_inv_filtered(eps_inv_w.shape(0), q_indices.size());
-          for (size_t i = 0; i < q_indices.size(); ++i) {
-            Q_filtered(i) = (poly_in_q2)? Q_abs2( q_indices[i] ) : Q_abs( q_indices[i] );
-            eps_inv_filtered(nda::range::all, i) = eps_inv_w(nda::range::all, q_indices[i] );
-          }
-          if ( q_indices.size() < 3) {
-            // Choose the closest point to the gamma instead
-            eps_inv_q0_t = eps_inv_t(nda::range::all, q_indices[0]);
-          } else {
-            if (two_dim)
-              app_log(2, "  Extrapolate head of the inverse of the dielectric function from {} q-points on the xy-plane", q_indices.size());
-            else
-              app_log(2, "  Extrapolate head of the inverse of the dielectric function from {} q-points", q_indices.size());
-            nda::array<ComplexType, 1> eps_inv_q0_w(nw);
-            for (int n = 0; n < nw; ++n) {
-              eps_inv_q0_w(n) = extrapolate_to_q0(Q_filtered, eps_inv_filtered(n, nda::range::all), fit_order,
-                                                  (dW_tqPQ.communicator()->root() and n==0)? true : false);
-            }
-            auto eps_inv_q0_w_2D = nda::reshape(eps_inv_q0_w, std::array<long,2>{nw, 1});
-            auto eps_inv_q0_t_2D = nda::reshape(eps_inv_q0_t, std::array<long,2>{nts,1});
-            ft->w_to_tau_PHsym(eps_inv_q0_w_2D, eps_inv_q0_t_2D);
-          }
-        } else {
-          // Choose the closest point to the gamma
-          int smallest_idx = find_smallest_qabs(mf.Qpts_ibz(), false);
-          eps_inv_q0_t = eps_inv_t(nda::range::all, smallest_idx);
-        }
+        // Perform q=0 extrapolation on frequency domain data
+        nda::array<ComplexType, 1> eps_inv_q0_w = 
+          extrapolate_eps_inv_q0(eps_inv_w, mf, div_treatment, poly_in_q2, q_max, fit_order);
+
+        // Convert result back to time domain
+        nda::array<ComplexType, 1> eps_inv_q0_t(nts);
+        auto eps_inv_q0_w_2D = nda::reshape(eps_inv_q0_w, std::array<long,2>{nw, 1});
+        auto eps_inv_q0_t_2D = nda::reshape(eps_inv_q0_t, std::array<long,2>{nts,1});
+        ft->w_to_tau_PHsym(eps_inv_q0_w_2D, eps_inv_q0_t_2D);
 
         return std::make_tuple(std::move(eps_inv_t), std::move(eps_inv_q0_t));
       }
@@ -147,91 +239,68 @@ namespace methods {
                                  bool poly_in_q2=false, double q_max=0.8, int fit_order=2)
       -> std::tuple<nda::array<ComplexType, 2>, nda::array<ComplexType, 1> > {
 
-        auto [eps_inv_w, Q_abs, Q_abs2] = eval_eps_inv_q(dW_wqPQ, thc, mf);
+        // Compute the head (i.e. G=G'=0 component) of the inverse dielectric function at finite q
+        auto eps_inv_w = eval_eps_inv_q(dW_wqPQ, thc, mf);
         auto [nw, nqpts_ibz] = eps_inv_w.shape();
 
         if (thc.MF()->nqpts_ibz() == 1 and div_treatment != ignore_g0) {
           app_log(2, "eps_inv_head_w: nqpts_ibz == 1 while div_treatment != ignore. "
-                     "Will take div_treatment = ignore_g0 anyway!");
+                     "CoQui will take div_treatment = ignore_g0 anyway!");
           div_treatment = ignore_g0;
         }
 
-        nda::array<ComplexType, 1> eps_inv_q0_w(nw);
-        if (div_treatment==gygi_extrplt or div_treatment==gygi_extrplt_2d) {
-          utils::check(mf.nkpts_ibz() > 1, "eps_inv_head_w: nkpts_ibz <= 1 while div_treatment==gygi_extrplt");
-          bool two_dim = (div_treatment==gygi_extrplt_2d)? true : false;
-          // extrapolation happens at frequency axis
-          auto q_indices = (poly_in_q2)? filter_qpts(mf.Qpts_ibz(), q_max, 2, two_dim) : filter_qpts(mf.Qpts_ibz(), q_max, 1, two_dim);
-          nda::array<ComplexType, 1> Q_filter(q_indices.size());
-          nda::array<ComplexType, 2> eps_inv_filter(eps_inv_w.shape(0), q_indices.size());
-          for (size_t i = 0; i < q_indices.size(); ++i) {
-            Q_filter(i) = (poly_in_q2)? Q_abs2( q_indices[i] ) : Q_abs( q_indices[i] );
-            eps_inv_filter(nda::range::all, i) = eps_inv_w(nda::range::all, q_indices[i] );
-          }
-          if ( q_indices.size() < 3) {
-            // Choose the closest point to the gamma instead
-            eps_inv_q0_w = eps_inv_w(nda::range::all, q_indices[0]);
-          } else {
-            if (two_dim)
-              app_log(2, "  Extrapolate head of the inverse of the dielectric function from {} q-points on the xy-plane", q_indices.size());
-            else
-              app_log(2, "  Extrapolate head of the inverse of the dielectric function from {} q-points", q_indices.size());
-            for (int n = 0; n < nw; ++n) {
-              eps_inv_q0_w(n) = extrapolate_to_q0(Q_filter, eps_inv_filter(n, nda::range::all), fit_order,
-                                                  (dW_wqPQ.communicator()->root() and n==0)? true : false);
-            }
-          }
-        } else {
-          // Choose the closest point to the gamma
-          int smallest_idx = find_smallest_qabs(mf.Qpts_ibz(), false);
-          eps_inv_q0_w = eps_inv_w(nda::range::all, smallest_idx);
-        }
+        // Perform q=0 extrapolation on frequency domain data
+        nda::array<ComplexType, 1> eps_inv_q0_w = 
+          extrapolate_eps_inv_q0(eps_inv_w, mf, div_treatment, poly_in_q2, q_max, fit_order);
 
         return std::make_tuple(std::move(eps_inv_w), std::move(eps_inv_q0_w));
       }
 
       /**
-       * Evaluate \epsilon^{q,-1}_{G=0,G'=0} - 1
-       * @param dW_tqPQ - [INPUT] screened interaction in the thc product basis
-       * @param thc - [INPUT] thc-eri instance
-       * @param mf - [INPUT] mean-field instance
-       * @return
+       * Extract the head (G=G'=0 component) of the inverse symmetric dielectric function at finite q
+       * 
+       * Computes \epsilon^{q,-1}_{G=0,G'=0} from the screened interaction W(x,q,P,Q) in the THC product basis.
+       * Works for W on both imaginary-time and Matsubara frequency axes.
+       * 
+       * @param dW_xqPQ    - [INPUT] screened interaction in the THC product basis
+       *                             with shape [nx, nqpts_ibz, NP, NQ], where x is the axis index
+       *                             (x can be time τ or Matsubara frequency iω)
+       * @param thc        - [INPUT] THC-ERI instance
+       * @param mf         - [INPUT] mean-field instance
+       * @return - head of inverse dielectric function with shape [nx, nqpts_ibz],
+       *           indexed as eps_inv_x(x_idx, q_idx)
        */
       template<nda::MemoryArrayOfRank<4> Array_w_t, THC_ERI thc_t, typename communicator_t>
-      static auto eval_eps_inv_q(memory::darray_t<Array_w_t, communicator_t> &dW_tqPQ,
+      static auto eval_eps_inv_q(memory::darray_t<Array_w_t, communicator_t> &dW_xqPQ,
                                  thc_t &thc, mf::MF &mf) {
-        auto [nt_loc, nq_loc, NP_loc, NQ_loc] = dW_tqPQ.local_shape();
-        auto t_rng = dW_tqPQ.local_range(0);
-        auto qpt_rng = dW_tqPQ.local_range(1);
-        auto P_rng = dW_tqPQ.local_range(2);
-        auto Q_rng = dW_tqPQ.local_range(3);
-        auto [nts, nqpts_ibz, NP, NQ] = dW_tqPQ.global_shape();
+        auto [nx_loc, nq_loc, NP_loc, NQ_loc] = dW_xqPQ.local_shape();
+        auto x_rng = dW_xqPQ.local_range(0);
+        auto qpt_rng = dW_xqPQ.local_range(1);
+        auto P_rng = dW_xqPQ.local_range(2);
+        auto Q_rng = dW_xqPQ.local_range(3);
+        auto [nx, nqpts_ibz, NP, NQ] = dW_xqPQ.global_shape();
 
-        nda::array<ComplexType, 1> Q_abs2(nqpts_ibz);
-        nda::array<ComplexType, 1> Q_abs(nqpts_ibz);
-        for (int iq = 0; iq < nqpts_ibz; ++iq) {
-          auto qpt = mf.Qpts_ibz(iq);
-          Q_abs2(iq) = ComplexType( qpt(0)*qpt(0) + qpt(1)*qpt(1) + qpt(2)*qpt(2) );
-          Q_abs(iq) = ComplexType( std::sqrt( qpt(0)*qpt(0) + qpt(1)*qpt(1) + qpt(2)*qpt(2) ) );
-        }
-
-        nda::array<ComplexType, 2> eps_inv_t(nts, nqpts_ibz);
+        nda::array<ComplexType, 2> eps_inv_x(nx, nqpts_ibz);
         nda::array<ComplexType, 1> Chi_bar_Q_conj(NQ_loc);
         nda::array<ComplexType, 1> buffer_P(NP_loc);
         const double fpi = 4.0*3.14159265358979323846;
         auto Chi_bar_qu = thc.basis_bar_head();
-        auto Wloc = dW_tqPQ.local();
+        auto Wloc = dW_xqPQ.local();
         for (auto [iq, q] : itertools::enumerate(qpt_rng)) {
+
+          auto qpts = mf.Qpts_ibz(q);
+          double q_abs2 = qpts(0)*qpts(0) + qpts(1)*qpts(1) + qpts(2)*qpts(2);
+
           Chi_bar_Q_conj = nda::conj(Chi_bar_qu(q, Q_rng));
-          double factor = (Q_abs2(q).real() / fpi) * mf.volume();
-          for (auto [it, t] : itertools::enumerate(t_rng)) {
-            nda::blas::gemv(Wloc(it, iq, nda::ellipsis{}), Chi_bar_Q_conj, buffer_P);
-            eps_inv_t(t, q) += factor * nda::blas::dot(Chi_bar_qu(q, P_rng), buffer_P);
+          double factor = (q_abs2 / fpi) * mf.volume();
+          for (auto [ix, x_idx] : itertools::enumerate(x_rng)) {
+            nda::blas::gemv(Wloc(ix, iq, nda::ellipsis{}), Chi_bar_Q_conj, buffer_P);
+            eps_inv_x(x_idx, q) += factor * nda::blas::dot(Chi_bar_qu(q, P_rng), buffer_P);
           }
         }
-        dW_tqPQ.communicator()->all_reduce_in_place_n(eps_inv_t.data(), eps_inv_t.size(), std::plus<>{});
+        dW_xqPQ.communicator()->all_reduce_in_place_n(eps_inv_x.data(), eps_inv_x.size(), std::plus<>{});
 
-        return std::make_tuple(eps_inv_t, Q_abs, Q_abs2);
+        return eps_inv_x;
       }
 
       /**
@@ -281,6 +350,66 @@ namespace methods {
         return m_t;
       }
 
+      /**
+       * Find the two closest points to origin along each Cartesian direction
+       * For a uniform 3D grid centered at origin spanning [-0.5, 0.5] in each direction,
+       * this function finds the two points with smallest positive coordinate values
+       * along x, y, and z directions. Only searches on the positive side (accounting for symmetry).
+       * @param Qpts      - [INPUT] array of q-points (shape: [nqpts, 3])
+       * @param recv      - [INPUT] reciprocal lattice vectors (shape: [3, 3])
+       * @param tolerance - [INPUT] threshold to consider a coordinate as zero (default: 1e-10)
+       * @return array of 3 vectors containing indices for x, y, z directions respectively
+       */
+      template<nda::ArrayOfRank<2> Array_2D_t, nda::ArrayOfRank<2> Array_2D_recv_t>
+      static std::array<std::vector<int>, 3> find_two_closest_per_direction(
+        Array_2D_t &&Qpts, Array_2D_recv_t &&recv, double tolerance=1e-10) {
+
+        if (Qpts.shape(0) == 1) return {{{0}, {0}, {0}}};
+        
+        // Convert to crystal coordinates using the reciprocal lattice vectors
+        nda::array<double, 2> Qpts_crys(Qpts.shape(0), 3);
+        for (int iq = 0; iq < Qpts.shape(0); ++iq) {
+          nda::blas::gemv(1.0, recv, Qpts(iq,nda::range::all), 0.0, Qpts_crys(iq,nda::range::all));
+        }
+        
+        std::array<std::vector<int>, 3> result_indices;
+        
+        // For each direction (x=0, y=1, z=2)
+        for (int dir = 0; dir < 3; ++dir) {
+          // Collect all positive values in this direction with their indices
+          std::vector<std::pair<double, int>> coord_idx_pairs;
+          
+          for (int i = 0; i < Qpts_crys.shape(0); ++i) {
+            double coord = Qpts_crys(i, dir);
+            
+            // Check if other dimensions are zero
+            bool other_dims_zero = true;
+            for (int other_dir = 0; other_dir < 3; ++other_dir) {
+              if (other_dir != dir && std::abs(Qpts_crys(i, other_dir)) > tolerance) {
+                other_dims_zero = false;
+                break;
+              }
+            }
+            
+            // Only consider positive coordinates with other dimensions zero
+            if (coord > tolerance && other_dims_zero) {
+              coord_idx_pairs.push_back({coord, i});
+            }
+          }
+          
+          // Sort by coordinate value
+          std::sort(coord_idx_pairs.begin(), coord_idx_pairs.end());
+          
+          // Collect the two smallest (or fewer if not enough points)
+          int count = std::min(2, static_cast<int>(coord_idx_pairs.size()));
+          for (int j = 0; j < count; ++j) {
+            result_indices[dir].push_back(coord_idx_pairs[j].second);
+          }
+        }
+        
+        return result_indices;
+      }
+
       template<nda::ArrayOfRank<2> Array_q_t>
       static int find_smallest_qabs(Array_q_t &&Qpts, bool two_dim=false) {
         if (Qpts.shape(0) == 1) return 0;
@@ -300,6 +429,58 @@ namespace methods {
           }
         }
         return idx;
+      }
+
+      /**
+       * Find all indices of q-points with the smallest absolute value
+       * Returns all q-points that share the same minimum |q| (accounting for symmetry)
+       * @param Qpts - [INPUT] array of q-points (shape: [nqpts, 3])
+       * @param two_dim - [INPUT] if true, only consider q-points with qpt(2)==0
+       * @param include_gamma - [INPUT] if true, include gamma point (q=0)
+       * @return vector of all indices with the minimum |q| value
+       */
+      template<nda::ArrayOfRank<2> Array_q_t>
+      static std::vector<int> find_smallest_qabs_indices(Array_q_t &&Qpts, bool two_dim=false, 
+                                                          bool include_gamma=false) {
+        if (Qpts.shape(0) == 1) return {0};
+        
+        double min_norm = -1.0;
+        constexpr double tolerance = 1e-10;
+        
+        // First pass: find the minimum norm
+        for (int i=0; i<Qpts.shape(0); ++i) {
+          auto qpt = Qpts(i,nda::range::all);
+          double norm = std::sqrt( qpt(0)*qpt(0) + qpt(1)*qpt(1) + qpt(2)*qpt(2) );
+          
+          // Skip gamma point if not requested
+          if (!include_gamma && norm < tolerance) continue;
+          
+          // For 2D, only consider points with qpt(2)==0
+          if (two_dim && std::abs(qpt(2)) > tolerance) continue;
+          
+          if (min_norm < 0.0 || norm < min_norm) {
+            min_norm = norm;
+          }
+        }
+        
+        // Second pass: collect all indices with the minimum norm
+        std::vector<int> indices;
+        for (int i=0; i<Qpts.shape(0); ++i) {
+          auto qpt = Qpts(i,nda::range::all);
+          double norm = std::sqrt( qpt(0)*qpt(0) + qpt(1)*qpt(1) + qpt(2)*qpt(2) );
+          
+          // Skip gamma point if not requested
+          if (!include_gamma && norm < tolerance) continue;
+          
+          // For 2D, only consider points with qpt(2)==0
+          if (two_dim && std::abs(qpt(2)) > tolerance) continue;
+          
+          if (std::abs(norm - min_norm) < tolerance) {
+            indices.push_back(i);
+          }
+        }
+        
+        return indices;
       }
 
       template<nda::ArrayOfRank<1> Array_q_t, nda::ArrayOfRank<1> Array_eps_t>

--- a/src/methods/GW/gw_t.cpp
+++ b/src/methods/GW/gw_t.cpp
@@ -31,13 +31,12 @@
 #include "mean_field/MF.hpp"
 #include "numerics/imag_axes_ft/IAFT.hpp"
 #include "methods/ERI/detail/concepts.hpp"
-#include "methods/ERI/div_treatment_e.hpp"
 #include "methods/GW/gw_t.h"
 
 namespace methods {
   namespace solvers {
 
-    gw_t::gw_t(const imag_axes_ft::IAFT *ft, div_treatment_e div, std::string output):
+    gw_t::gw_t(const imag_axes_ft::IAFT *ft, std::string div, std::string output):
        _ft(ft),
        _div_treatment(div),
        _output(output),

--- a/src/methods/GW/gw_t.h
+++ b/src/methods/GW/gw_t.h
@@ -35,7 +35,6 @@
 #include "numerics/imag_axes_ft/IAFT.hpp"
 #include "methods/scr_coulomb/scr_coulomb_t.h"
 #include "methods/ERI/detail/concepts.hpp"
-#include "methods/ERI/div_treatment_e.hpp"
 
 namespace methods {
   namespace solvers {
@@ -61,7 +60,7 @@ namespace methods {
       using shape_t = std::array<long,N>;
 
     public:
-      gw_t(const imag_axes_ft::IAFT *ft, div_treatment_e div = gygi,
+      gw_t(const imag_axes_ft::IAFT *ft, std::string div = "gygi",
            std::string output = "coqui");
 
       ~gw_t() {}
@@ -246,7 +245,7 @@ namespace methods {
     private:
       const imag_axes_ft::IAFT* _ft = nullptr;
 
-      div_treatment_e _div_treatment = div_treatment_e::ignore_g0;
+      std::string _div_treatment = "ignore_g0";
 
       // current iteration in SCF. Modified externally.
       long _iter = 0;
@@ -256,7 +255,7 @@ namespace methods {
     public:
       long& iter() { return _iter; }
       std::string& output() { return _output; }
-      div_treatment_e& div_treatmemnt() { return _div_treatment; }
+      std::string& div_treatmemnt() { return _div_treatment; }
 
     };
   } // solvers

--- a/src/methods/GW/gw_t.h
+++ b/src/methods/GW/gw_t.h
@@ -255,7 +255,7 @@ namespace methods {
     public:
       long& iter() { return _iter; }
       std::string& output() { return _output; }
-      std::string& div_treatmemnt() { return _div_treatment; }
+      std::string& div_treatment() { return _div_treatment; }
 
     };
   } // solvers

--- a/src/methods/GW/tests/test_chol_gw.cpp
+++ b/src/methods/GW/tests/test_chol_gw.cpp
@@ -51,8 +51,8 @@ namespace bdft_tests {
 
     auto solve_thc_g0w0 = [&](std::shared_ptr<mf::MF> &mf) {
       solvers::hf_t hf;
-      solvers::gw_t gw(&ft, string_to_div_enum("ignore_g0"), output);
-      solvers::scr_coulomb_t scr_eri(&ft, "rpa", string_to_div_enum("ignore_g0"));
+      solvers::gw_t gw(&ft, "ignore_g0", output);
+      solvers::scr_coulomb_t scr_eri(&ft, "rpa", "ignore_g0");
 
       chol_reader_t chol(mf, methods::make_chol_reader_ptree(1e-10, mf->ecutrho(), 32, "./"));
       auto eri = mb_eri_t(chol, chol);
@@ -120,7 +120,7 @@ namespace bdft_tests {
     imag_axes_ft::IAFT ft(1000, 1.2, imag_axes_ft::ir_source);
     chol_reader_t chol(mf, methods::make_chol_reader_ptree(1e-10, mf->ecutrho(), 32, "./"));
     auto eri = mb_eri_t(chol, chol);
-    solvers::gw_t gw(std::addressof(ft));
+    solvers::gw_t gw(std::addressof(ft), "gygi_smallest_q");
     solvers::hf_t hf;
     simple_dyson dyson(mf.get(), std::addressof(ft));
     MBState mb_state(mpi_context, ft, "bdft");
@@ -152,7 +152,7 @@ namespace bdft_tests {
     imag_axes_ft::IAFT ft(1000, 1.2, imag_axes_ft::ir_source);
     chol_reader_t chol(mf, methods::make_chol_reader_ptree(1e-10, mf->ecutrho(), 32, "./"));
     auto eri = mb_eri_t(chol, chol);
-    solvers::gw_t gw(std::addressof(ft));
+    solvers::gw_t gw(std::addressof(ft), "gygi_smallest_q");
     solvers::hf_t hf;
     solvers::mb_solver_t mb_solver(&hf, &gw);
     simple_dyson dyson(mf.get(), std::addressof(ft));
@@ -184,7 +184,7 @@ namespace bdft_tests {
     imag_axes_ft::IAFT ft(1000, 12.0, imag_axes_ft::ir_source);
     chol_reader_t chol(mf, methods::make_chol_reader_ptree(1e-10, mf->ecutrho(), 32, "./"));
     auto eri = mb_eri_t(chol, chol);
-    solvers::gw_t gw(std::addressof(ft));
+    solvers::gw_t gw(std::addressof(ft), "gygi_smallest_q");
     solvers::hf_t hf;
     simple_dyson dyson(mf.get(), std::addressof(ft));
     MBState mb_state(mpi_context, ft, "bdft");
@@ -219,7 +219,7 @@ namespace bdft_tests {
     imag_axes_ft::IAFT ft(1000, 12.0, imag_axes_ft::ir_source);
     chol_reader_t chol(mf, methods::make_chol_reader_ptree(1e-10, mf->ecutrho(), 32, "./"));
     auto eri = mb_eri_t(chol, chol);
-    solvers::gw_t gw(std::addressof(ft));
+    solvers::gw_t gw(std::addressof(ft), "gygi_smallest_q");
     solvers::hf_t hf;
     solvers::mb_solver_t mb_solver(&hf, &gw);
     simple_dyson dyson(mf.get(), std::addressof(ft));
@@ -249,7 +249,7 @@ namespace bdft_tests {
 
     chol_reader_t chol(mf, gdf_dir);
     auto eri = mb_eri_t(chol, chol);
-    solvers::gw_t gw(&ft);
+    solvers::gw_t gw(&ft, "gygi_smallest_q");
     solvers::hf_t hf;
     simple_dyson dyson(mf.get(), &ft);
     MBState mb_state(mpi_context, ft, "bdft");

--- a/src/methods/GW/tests/test_thc_gw.cpp
+++ b/src/methods/GW/tests/test_thc_gw.cpp
@@ -51,8 +51,8 @@ namespace bdft_tests {
 
     auto solve_thc_g0w0 = [&](std::shared_ptr<mf::MF> &mf) {
       solvers::hf_t hf;
-      solvers::gw_t gw(&ft, string_to_div_enum("ignore_g0"), output);
-      solvers::scr_coulomb_t scr_eri(&ft, "rpa", string_to_div_enum("ignore_g0"));
+      solvers::gw_t gw(&ft, "ignore_g0", output);
+      solvers::scr_coulomb_t scr_eri(&ft, "rpa", "ignore_g0");
 
       thc_reader_t thc(mf, make_thc_reader_ptree(mf->nbnd()*24, "", "incore", "", "bdft",
                                                  1e-10, mf->ecutrho(), 1, 1024));
@@ -127,8 +127,8 @@ namespace bdft_tests {
       std::string output = "coqui";
 
       solvers::hf_t hf;
-      solvers::gw_t gw(&ft, string_to_div_enum("ignore_g0"), output);
-      solvers::scr_coulomb_t scr_eri(&ft, "rpa", string_to_div_enum("ignore_g0"));
+      solvers::gw_t gw(&ft, "ignore_g0", output);
+      solvers::scr_coulomb_t scr_eri(&ft, "rpa", "ignore_g0");
       simple_dyson dyson(mf.get(), &ft);
       MBState mb_state(mpi_context, ft, output);
 
@@ -196,7 +196,7 @@ namespace bdft_tests {
       imag_axes_ft::IAFT ft(1000, wmax, imag_axes_ft::ir_source);
 
       solvers::hf_t hf;
-      solvers::gw_t gw(&ft);
+      solvers::gw_t gw(&ft, "gygi_smallest_q");
 
       /**
        * Reference value is obtained from Chol-RPA with ERIs converge to 1e-10.
@@ -237,7 +237,7 @@ namespace bdft_tests {
     auto mf = std::make_shared<mf::MF>(mf::default_MF(mpi_context, mf::pyscf_source));
     imag_axes_ft::IAFT ft(1000, 12.0, imag_axes_ft::ir_source);
     solvers::hf_t hf;
-    solvers::gw_t gw(&ft, string_to_div_enum("ignore_g0"), output);
+    solvers::gw_t gw(&ft, "ignore_g0", output);
 
     /**
      * Reference value is obtained from Chol-GW with ERIs converge to 1e-10.
@@ -250,7 +250,7 @@ namespace bdft_tests {
                                                  1e-10, mf->ecutrho(), 1, 1024));
       auto eri = mb_eri_t(thc, thc);
       iter_scf::iter_scf_t iter_sol("damping");
-      solvers::scr_coulomb_t scr_eri(&ft, "rpa", string_to_div_enum("ignore_g0"));
+      solvers::scr_coulomb_t scr_eri(&ft, "rpa", "ignore_g0");
       auto [e_hf, e_corr] = scf_loop(mb_state, dyson, eri, ft,
                                      solvers::mb_solver_t(&hf,&gw,&scr_eri), &iter_sol,
                                      1, false, 1e-9, true);
@@ -267,7 +267,7 @@ namespace bdft_tests {
       thc_reader_t thc(mf, "outcore", "./thc_eri.h5");
       auto eri = mb_eri_t(thc, thc);
       iter_scf::iter_scf_t iter_sol("damping");
-      solvers::scr_coulomb_t scr_eri(&ft, "rpa", string_to_div_enum("ignore_g0"));
+      solvers::scr_coulomb_t scr_eri(&ft, "rpa", "ignore_g0");
       auto [e_hf, e_corr] = scf_loop(mb_state, dyson, eri, ft,
                                      solvers::mb_solver_t(&hf,&gw,&scr_eri), &iter_sol,
                                      1, false, 1e-9, true);
@@ -293,7 +293,7 @@ namespace bdft_tests {
     auto mf = std::make_shared<mf::MF>(mf::default_MF(mpi_context, mf::pyscf_source));
     imag_axes_ft::IAFT ft(1000, 12.0, imag_axes_ft::ir_source);
     solvers::hf_t hf;
-    solvers::gw_t gw(&ft);
+    solvers::gw_t gw(&ft, "gygi_smallest_q");
     solvers::mb_solver_t mb_solver(&hf, &gw);
 
     { // incore thc-rpa
@@ -331,8 +331,8 @@ namespace bdft_tests {
 
     auto solve_gdf_thc_gw = [&](std::shared_ptr<mf::MF> &mf, std::string gdf_dir) {
       solvers::hf_t hf;
-      solvers::gw_t gw(&ft, string_to_div_enum("ignore_g0"), output);
-      solvers::scr_coulomb_t scr_eri(&ft, "rpa", string_to_div_enum("ignore_g0"));
+      solvers::gw_t gw(&ft, "ignore_g0", output);
+      solvers::scr_coulomb_t scr_eri(&ft, "rpa", "ignore_g0");
       /**
        * References are obtained from the same GDF-THC-GW with alpha=12
        * The accuracy is roughly 1e-4 at Np=280 (alpha~11.67) for this system.

--- a/src/methods/GW/thc_gw.cpp
+++ b/src/methods/GW/thc_gw.cpp
@@ -35,7 +35,6 @@
 #include "mean_field/MF.hpp"
 #include "methods/ERI/detail/concepts.hpp"
 #include "methods/HF/thc_solver_comm.hpp"
-#include "methods/ERI/div_treatment_e.hpp"
 #include "methods/GW/g0_div_utils.hpp"
 
 #include "methods/ERI/thc_reader_t.hpp"
@@ -59,7 +58,7 @@ namespace methods {
                    "  Divergent treatment at q->0   = {}\n",
                 mb_state.screen_type,
                 thc.MF()->nbnd(), thc.Np(), thc.MF()->nkpts(), thc.MF()->nkpts_ibz(),
-                div_enum_to_string(_div_treatment));
+                _div_treatment);
         _ft->metadata_log();
       }
       utils::check(mb_state.mpi == thc.mpi(),
@@ -125,7 +124,7 @@ namespace methods {
                    "  divergent treatment at q->0 = {}\n",
                 scr_eri->screen_type(),
                 thc.MF()->nbnd(), thc.Np(), thc.MF()->nkpts(), thc.MF()->nkpts_ibz(),
-                div_enum_to_string(_div_treatment));
+                _div_treatment);
         _ft->metadata_log();
       }
       utils::check(_ft->nt_f() == _ft->nt_b(),

--- a/src/methods/GW/thc_gw.icc
+++ b/src/methods/GW/thc_gw.icc
@@ -457,9 +457,11 @@ namespace methods {
         div_treatment = ignore_g0;
       }
 
-      if (div_treatment == ignore_g0) {
+      auto div_string = div_enum_to_string(div_treatment);
+
+      if (div_string == "ignore_g0") {
         return;
-      } else if (div_treatment==gygi or div_treatment==gygi_extrplt or div_treatment==gygi_extrplt_2d) {
+      } else if (div_string.find("gygi") != std::string::npos) {
         auto MF = thc.MF();
         auto mpi = thc.mpi();
         app_log(1, "    - madelung = {}", MF->madelung());

--- a/src/methods/GW/thc_gw.icc
+++ b/src/methods/GW/thc_gw.icc
@@ -17,7 +17,6 @@
 #include "mean_field/MF.hpp"
 #include "methods/ERI/detail/concepts.hpp"
 #include "methods/HF/thc_solver_comm.hpp"
-#include "methods/ERI/div_treatment_e.hpp"
 #include "methods/GW/g0_div_utils.hpp"
 
 namespace methods {
@@ -448,20 +447,18 @@ namespace methods {
                               THC_ERI auto &thc,
                               const nda::array<ComplexType, 1> &eps_inv_head) {
       app_log(1, "  Treatment of long-wavelength divergence in GW self-energy: {}",
-              div_enum_to_string(_div_treatment));
+              _div_treatment);
 
       auto div_treatment = _div_treatment;
-      if (thc.MF()->nqpts_ibz() == 1 and _div_treatment != ignore_g0) {
+      if (thc.MF()->nqpts_ibz() == 1 and _div_treatment != "ignore_g0") {
         app_log(2, "Sigma_div_correction: nqpts_ibz == 1 while div_treatment != ignore. "
                    "Will take div_treatment = ignore_g0 anyway!");
-        div_treatment = ignore_g0;
+        div_treatment = "ignore_g0";
       }
 
-      auto div_string = div_enum_to_string(div_treatment);
-
-      if (div_string == "ignore_g0") {
+      if (div_treatment == "ignore_g0") {
         return;
-      } else if (div_string.find("gygi") != std::string::npos) {
+      } else if (div_treatment.find("gygi") != std::string::npos) {
         auto MF = thc.MF();
         auto mpi = thc.mpi();
         app_log(1, "    - madelung = {}", MF->madelung());
@@ -522,7 +519,7 @@ namespace methods {
           sSigma_tskij.local() += sDelta_tskij.local();
         sSigma_tskij.communicator()->barrier();
       } else {
-        utils::check(false, "Unsupported divergence treatment: {}", div_enum_to_string(div_treatment));
+        utils::check(false, "Unsupported divergence treatment: {}", div_treatment);
       }
       app_log(1, "");
     }

--- a/src/methods/HF/cholesky_hf.cpp
+++ b/src/methods/HF/cholesky_hf.cpp
@@ -50,7 +50,7 @@ namespace methods {
                  "  divergent treatment at q->0 = {}\n",
               hartree, exchange,
               chol.MF()->nbnd(), chol.Np(), chol.MF()->nkpts(), chol.MF()->nkpts_ibz(),
-              div_enum_to_string(_div_treatment));
+              _div_treatment);
       utils::check(chol.MF()->nkpts() == chol.MF()->nkpts_ibz(), "hf_t::cholesky_hf::evaluate: Symmetry not yet implemented.");
 
       for( auto& v: {"TOTAL", "ALLOC",

--- a/src/methods/HF/hf_t.cpp
+++ b/src/methods/HF/hf_t.cpp
@@ -30,7 +30,6 @@
 
 #include "mean_field/MF.hpp"
 #include "methods/ERI/detail/concepts.hpp"
-#include "methods/ERI/div_treatment_e.hpp"
 
 #include "methods/HF/hf_t.h"
 
@@ -49,11 +48,11 @@ namespace methods {
      *   myhf.evaluate(F_chol, Dm, cholesky_eri); // Cholesky-HF
      *
      */
-    hf_t::hf_t(div_treatment_e div): _div_treatment(div), _Timer() {
-      if (_div_treatment!=ignore_g0 and _div_treatment!=gygi) {
+    hf_t::hf_t(std::string div): _div_treatment(div), _Timer() {
+      if (_div_treatment!="ignore_g0" and _div_treatment!="gygi") {
         app_log(2, " hf_t: div_treatment only supports \"ignore_g0\" and \"gygi\". "
                    " coqui will take div_treatment = \"gygi\" instead.");
-        _div_treatment = gygi;
+        _div_treatment = "gygi";
       }
     }
 
@@ -67,12 +66,12 @@ namespace methods {
                          const nda::MemoryArrayOfRank<4> auto &S_skij,
                          double madelung) {
 
-      if (_div_treatment == ignore_g0) {
+      if (_div_treatment == "ignore_g0") {
         app_log(1, "No finite-size correction to the non-local HF exchange potential.\n");
         return;
       }
       app_log(1, "  Treatment of long-wavelength divergence in the non-local HF exchange potential : {}\n",
-              div_enum_to_string(_div_treatment));
+              _div_treatment);
 
       decltype(nda::range::all) all;
       long ns = Dm_skij.extent(0);

--- a/src/methods/HF/hf_t.h
+++ b/src/methods/HF/hf_t.h
@@ -32,7 +32,6 @@
 
 #include "mean_field/MF.hpp"
 #include "methods/ERI/detail/concepts.hpp"
-#include "methods/ERI/div_treatment_e.hpp"
 
 namespace methods {
   namespace solvers {
@@ -59,7 +58,7 @@ namespace methods {
       using shape_t = std::array<long,N>;
 
     public:
-      hf_t(div_treatment_e div = gygi);
+      hf_t(std::string div = "gygi");
 
       ~hf_t() = default;
 
@@ -119,12 +118,12 @@ namespace methods {
       void HF_K_correction(sArray_t<AF_t> &sF_skij, const nda::MemoryArrayOfRank<4> auto &Dm_skij, 
                            const nda::MemoryArrayOfRank<4> auto &S_skij, double madelung);
 
-      div_treatment_e& div_treatmemnt() { return _div_treatment; }
+      std::string& div_treatmemnt() { return _div_treatment; }
       void print_chol_hf_timers(); 
       void print_thc_hf_timers(); 
 
     private:
-      div_treatment_e _div_treatment;
+      std::string _div_treatment;
 
       utils::TimerManager _Timer;
 

--- a/src/methods/HF/hf_t.h
+++ b/src/methods/HF/hf_t.h
@@ -118,7 +118,7 @@ namespace methods {
       void HF_K_correction(sArray_t<AF_t> &sF_skij, const nda::MemoryArrayOfRank<4> auto &Dm_skij, 
                            const nda::MemoryArrayOfRank<4> auto &S_skij, double madelung);
 
-      std::string& div_treatmemnt() { return _div_treatment; }
+      std::string& div_treatment() { return _div_treatment; }
       void print_chol_hf_timers(); 
       void print_thc_hf_timers(); 
 

--- a/src/methods/HF/tests/test_thc_hf.cpp
+++ b/src/methods/HF/tests/test_thc_hf.cpp
@@ -57,7 +57,7 @@ namespace bdft_tests {
     auto eval_thc_hf = [&](std::shared_ptr<mf::MF> &mf) {
       thc_reader_t thc(mf, methods::make_thc_reader_ptree(0.0, "", "incore", "", "bdft", 1e-5,
                                                       0.4*mf->ecutrho()));
-      solvers::hf_t hf(methods::ignore_g0);
+      solvers::hf_t hf("ignore_g0");
 
       long nspin = mf->nspin();
       long nkpts_ibz = mf->nkpts_ibz();

--- a/src/methods/HF/thc_hf.cpp
+++ b/src/methods/HF/thc_hf.cpp
@@ -56,7 +56,7 @@ namespace methods {
                  "  Divergent treatment at q->0   = {}\n",
                  hartree, exchange, thc.MF()->nspin(), thc.MF()->npol(),
                  thc.MF()->nbnd(), thc.Np(), thc.MF()->nkpts(), thc.MF()->nkpts_ibz(),
-                 div_enum_to_string(_div_treatment));
+                 _div_treatment);
 
       for( auto& v: {"TOTAL", "ALLOC",
                      "PRIM_TO_AUX", "AUX_TO_PRIM",

--- a/src/methods/MBPT_drivers.cpp
+++ b/src/methods/MBPT_drivers.cpp
@@ -37,7 +37,6 @@
 #include "mean_field/mf_utils.hpp"
 #include "methods/ERI/mb_eri_context.h"
 #include "methods/mb_state/mb_state.hpp"
-#include "methods/ERI/div_treatment_e.hpp"
 #include "methods/SCF/dca_dyson.h"
 #include "methods/SCF/simple_dyson.h"
 #include "methods/embedding/embed_t.h"
@@ -161,11 +160,10 @@ void mbpt(std::string solver_type, eri_t &eri, ptree const& pt)
   std::unique_ptr<iter_scf::iter_scf_t> iter_solver;
 
   using namespace solvers;
-  hf_t hf(string_to_div_enum(hf_div_treatment));
+  hf_t hf(hf_div_treatment);
   if(solver_type == "rpa") {
     simple_dyson dyson(mf.get(), &ft, mu_tol);
-    //solvers::scr_coulomb_t scr_eri(&ft, "rpa", string_to_div_enum(div_treatment));
-    gw_t gw(&ft, string_to_div_enum(div_treatment), output);
+    gw_t gw(&ft, div_treatment, output);
     MBState mb_state(mpi, ft, output);
     rpa_loop(mb_state, dyson, eri, ft, mb_solver_t(&hf,&gw));
   } else if(solver_type == "hf") {
@@ -190,8 +188,8 @@ void mbpt(std::string solver_type, eri_t &eri, ptree const& pt)
     } else {
       iter_solver = nullptr;
     }
-    solvers::scr_coulomb_t scr_eri(&ft, screen_type, string_to_div_enum(div_treatment));
-    solvers::gw_t gw(&ft, string_to_div_enum(div_treatment), output);
+    solvers::scr_coulomb_t scr_eri(&ft, screen_type, div_treatment);
+    solvers::gw_t gw(&ft, div_treatment, output);
     if (screen_type.substr(0,8)=="gw_edmft") {
 
       auto wannier_file = io::get_value<std::string>(pt,"wannier_file",err+"wannier_file");
@@ -250,7 +248,7 @@ void mbpt(std::string solver_type, eri_t &eri, ptree const& pt)
     } else {
       iter_solver = nullptr;
     }
-    solvers::gf2_t gf2(mf.get(), &ft, string_to_div_enum(div_treatment),
+    solvers::gf2_t gf2(mf.get(), &ft, div_treatment,
                        gf2_direct_type, gf2_exchange_alg, gf2_exchange_type, output,
                        gf2_save_C, gf2_sosex_save_memory);
     gf2.t_thresh() = t_prescreen_thresh;
@@ -262,7 +260,7 @@ void mbpt(std::string solver_type, eri_t &eri, ptree const& pt)
                iter_solver.get(), niter, restart, conv_thr, const_mu,
                greens_func_source, greens_func_iteration);
     } else {
-      solvers::scr_coulomb_t scr_eri(&ft, "rpa", string_to_div_enum(div_treatment));
+      solvers::scr_coulomb_t scr_eri(&ft, "rpa", div_treatment);
       scf_loop(mb_state, dyson, eri, ft, mb_solver_t(&hf, &gf2, &scr_eri),
                iter_solver.get(), niter, restart, conv_thr, const_mu,
                greens_func_source, greens_func_iteration);
@@ -276,7 +274,7 @@ void mbpt(std::string solver_type, eri_t &eri, ptree const& pt)
         "qe" : (mf.mf_type()==mf::pyscf_source)? "pyscf" : "bdft";
     mf::MF dca_mf(mf::make_MF(mpi, dca_pt, mf_type));
     dca_dyson dyson(mpi, &mf, &ft, dca_mf);
-    solvers::gw_t gw(&ft, string_to_div_enum(div_treatment), output);
+    solvers::gw_t gw(&ft, div_treatment, output);
     scf_loop(dyson, eri, ft, mb_solver_t(&hf,&gw), nullptr,
              output, niter, restart, conv_thr, const_mu);*/
 
@@ -306,8 +304,8 @@ void mbpt(std::string solver_type, eri_t &eri, ptree const& pt)
     } else {
       iter_solver = nullptr;
     }
-    solvers::scr_coulomb_t scr_eri(&ft, "rpa", string_to_div_enum(div_treatment));
-    solvers::gw_t gw(&ft, string_to_div_enum(div_treatment), output);
+    solvers::scr_coulomb_t scr_eri(&ft, "rpa", div_treatment);
+    solvers::gw_t gw(&ft, div_treatment, output);
     MBState mb_state(mpi, ft, output);
     qp_scf_loop<true>(mb_state, eri, ft, qp_context, mb_solver_t(&hf,&gw,&scr_eri), iter_solver.get(),
                       niter, restart, conv_thr);
@@ -328,8 +326,8 @@ void mbpt(std::string solver_type, eri_t &eri, ptree const& pt)
     } else {
       iter_solver = nullptr;
     }
-    solvers::scr_coulomb_t scr_eri(&ft, "rpa", string_to_div_enum(div_treatment));
-    solvers::gw_t gw(&ft, string_to_div_enum(div_treatment), output);
+    solvers::scr_coulomb_t scr_eri(&ft, "rpa", div_treatment);
+    solvers::gw_t gw(&ft, div_treatment, output);
     MBState mb_state(mpi, ft, output);
     qp_scf_loop<false>(mb_state, eri, ft, qp_context, mb_solver_t(&hf,&gw,&scr_eri), iter_solver.get(),
                        niter, restart, conv_thr);
@@ -399,7 +397,7 @@ void mbpt(std::string solver_type, eri_t &eri, ptree const& pt,
   std::unique_ptr<iter_scf::iter_scf_t> iter_solver;
 
   using namespace solvers;
-  hf_t hf(string_to_div_enum(hf_div_treatment));
+  hf_t hf(hf_div_treatment);
   if (solver_type == "gw") {
 
     auto screen_type = io::get_value_with_default<std::string>(pt,"screen_type", "rpa");
@@ -410,8 +408,8 @@ void mbpt(std::string solver_type, eri_t &eri, ptree const& pt,
     } else {
       iter_solver = nullptr;
     }
-    solvers::scr_coulomb_t scr_eri(&ft, screen_type, string_to_div_enum(div_treatment));
-    solvers::gw_t gw(&ft, string_to_div_enum(div_treatment), output);
+    solvers::scr_coulomb_t scr_eri(&ft, screen_type, div_treatment);
+    solvers::gw_t gw(&ft, div_treatment, output);
     MBState mb_state(ft, output, mf, projector_ksIai, band_window, kpts_crys, trans_home_cell, false);
     if (local_polarizabilities) {
       mb_state.set_local_polarizabilities(std::move(local_polarizabilities.value()));
@@ -526,8 +524,7 @@ downfold_coulomb_impl(eri_t &eri, MBState&& mb_state, ptree const& pt,
     mb_state.set_local_polarizabilities(std::move(local_polarizabilities.value()));
     local_polarizabilities.reset();
   }
-  embed_eri_t embed_eri(*mf, string_to_div_enum(div_treatment),
-              string_to_div_enum(bare_div_treatment), "default");
+  embed_eri_t embed_eri(*mf, div_treatment, bare_div_treatment, "default");
   return (output_in_tau)?
     embed_eri.compute_downfolded_coulomb_tensors<true>(
       eri, mb_state, screen_type, permut_symm, force_real, mb_state.ft, 
@@ -625,8 +622,7 @@ void downfolding_2e(eri_t &eri, ptree const& pt,
     local_polarizabilities.reset();
   }
 
-  embed_eri_t embed_eri(*mf, string_to_div_enum(div_treatment),
-                        string_to_div_enum(bare_div_treatment), "default");
+  embed_eri_t embed_eri(*mf, div_treatment, bare_div_treatment, "default");
 
   if (screen_type.substr(0, 8) == "gw_edmft") {
     embed_eri.downfolding_edmft(eri, mb_state, pt, screen_type);
@@ -695,8 +691,7 @@ void hf_downfold(eri_t &eri, ptree const& pt) {
   MBState mb_state(ft, output, mf, wannier_file, trans_home_cell, false);
 
   // Two-body Hamiltonian
-  embed_eri_t embed_eri(*mf, ignore_g0,
-                        string_to_div_enum(hf_div_treatment), "model_static");
+  embed_eri_t embed_eri(*mf, "ignore_g0", hf_div_treatment, "model_static");
   embed_eri.downfolding_crpa(eri, mb_state, pt, "bare", factorization_type,
                              io::get_value_with_default<double>(pt, "thresh", 1e-6));
 
@@ -704,7 +699,7 @@ void hf_downfold(eri_t &eri, ptree const& pt) {
   embed_t embed(*mf, wannier_file, trans_home_cell);
   embed.hf_downfolding(outdir, prefix, eri, ft,
                        io::get_value_with_default<bool>(pt, "force_real", true),
-                       string_to_div_enum(hf_div_treatment));
+                       hf_div_treatment);
 
 }
 
@@ -770,8 +765,7 @@ void gw_downfold(eri_t &eri, ptree &pt) {
   MBState mb_state(ft, output, mf, wannier_file, trans_home_cell, false);
 
   // Two-body Hamiltonian
-  embed_eri_t embed_eri(*mf, string_to_div_enum(div_treatment),
-                        string_to_div_enum(hf_div_treatment), "model_static");
+  embed_eri_t embed_eri(*mf, div_treatment, hf_div_treatment, "model_static");
   embed_eri.downfolding_crpa(eri, mb_state, pt, "crpa", factorization_type,
                              io::get_value_with_default<double>(pt, "thresh", 1e-6));
 

--- a/src/methods/embedding/dc_utilities.hpp
+++ b/src/methods/embedding/dc_utilities.hpp
@@ -160,7 +160,7 @@ nda::array<ComplexType, 4> exchange_double_counting(const nda::MemoryArrayOfRank
     std::string prefix = "__dummy_model__";
     auto mf = std::make_shared<mf::MF>(mf::MF(mf::model::make_dummy_model(mpi,nb,1.0)));
     solvers::hf_t hf;
-    solvers::gw_t gw(&ft, string_to_div_enum("ignore_g0"), prefix);
+    solvers::gw_t gw(&ft, "ignore_g0", prefix);
     chol_reader_t chol(mf, "./", chol_file, each_q, single_file);
 
     sArray_t<Array_view_5D_t> Sigma_shm(math::shm::make_shared_array<Array_view_5D_t>(

--- a/src/methods/embedding/downfold_1e.cpp
+++ b/src/methods/embedding/downfold_1e.cpp
@@ -147,7 +147,7 @@ namespace methods {
   template<THC_ERI thc_t>
   void embed_t::hf_downfolding(std::string outdir, std::string prefix,
                       thc_t& eri, imag_axes_ft::IAFT &ft,
-                      bool force_real, div_treatment_e hf_div_treatment) {
+                      bool force_real, std::string hf_div_treatment) {
 
     prefix = outdir + "/" + prefix;
     downfold_hf_impl(prefix, eri, ft, force_real, hf_div_treatment);
@@ -869,7 +869,7 @@ namespace methods {
                                  thc_t& eri,
                                  imag_axes_ft::IAFT &ft,
                                  bool force_real,
-                                 div_treatment_e hf_div_treatment) {
+                                 std::string hf_div_treatment) {
     using math::shm::make_shared_array;
     decltype(nda::range::all) all;
 
@@ -1492,6 +1492,6 @@ namespace methods {
 namespace methods {
 
 template void embed_t::hf_downfolding(std::string, std::string,
-    thc_reader_t&, imag_axes_ft::IAFT&, bool, div_treatment_e);
+  thc_reader_t&, imag_axes_ft::IAFT&, bool, std::string);
 
 }

--- a/src/methods/embedding/embed_eri_t.cpp
+++ b/src/methods/embedding/embed_eri_t.cpp
@@ -612,8 +612,8 @@ namespace methods {
 
       _Timer.start("DF_DOWNFOLD");
       auto dV_qPQ = eri.dZ({1, 1, mpi->comm.size()});
-      app_log(1, "Treatment of long-wavelength divergence in V (bare): {}", div_enum_to_string(_bare_div_treatment));
-      auto div_factor = ( _bare_div_treatment == ignore_g0 ? ComplexType(0.0) : ComplexType(1.0) );
+      app_log(1, "Treatment of long-wavelength divergence in V (bare): {}", _bare_div_treatment);
+      auto div_factor = ( _bare_div_treatment == "ignore_g0") ? ComplexType(0.0) : ComplexType(1.0);
       auto V_nab = ( factorization_type=="cholesky" ? 
                      downfold_cholesky(eri, proj_boson, dV_qPQ, div_factor, thresh) :
                      downfold_cholesky_high_memory(eri, proj_boson, dV_qPQ, div_factor, thresh) );
@@ -1536,10 +1536,10 @@ namespace methods {
       dV_qPQ.local() += dW_wqPQ.local()(0,nda::ellipsis{});
     }
     dW_wqPQ.reset();
-    app_log(1, "Treatment of long-wavelength divergence in V (bare): {}", div_enum_to_string(_bare_div_treatment));
-    app_log(1, "Treatment of long-wavelength divergence in W: {}", div_enum_to_string(_div_treatment));
-    auto div_factor = ( _bare_div_treatment == ignore_g0 ? ComplexType(0.0) : ComplexType(1.0) );
-    div_factor += ( _div_treatment == ignore_g0 ? ComplexType(0.0) : eps_inv_head_w(0) );
+    app_log(1, "Treatment of long-wavelength divergence in V (bare): {}", _bare_div_treatment);
+    app_log(1, "Treatment of long-wavelength divergence in W: {}", _div_treatment);
+    auto div_factor = ( _bare_div_treatment == "ignore_g0" )? ComplexType(0.0) : ComplexType(1.0);
+    div_factor += ( _div_treatment == "ignore_g0" ) ? ComplexType(0.0) : eps_inv_head_w(0);
     auto W_nab = ( factorization_type=="cholesky" ?
                    downfold_cholesky(thc, mb_state.proj_boson.value(), dV_qPQ, div_factor, thresh) :
                    downfold_cholesky_high_memory(thc, mb_state.proj_boson.value(), dV_qPQ, div_factor, thresh) );
@@ -2206,7 +2206,7 @@ namespace methods {
   template<THC_ERI thc_t, nda::ArrayOfRank<5> B_t>
   void embed_eri_t::V_div_correction(nda::array<ComplexType, 4> &V_cdab,
                                 const B_t &B_qIPab, thc_t &thc) {
-    auto div_string = div_enum_to_string(_bare_div_treatment);
+    auto div_string = _bare_div_treatment;
     if (div_string == "ignore_g0") {
       app_log(1, "No finite-size correction for the long-wavelength divergence in "
                  "the local bare V. ");
@@ -2214,7 +2214,7 @@ namespace methods {
     }
     app_log(1, "  Treatment of long-wavelength divergence in bare V: {}\n"
                "    - madelung = {}\n",
-            div_enum_to_string(_bare_div_treatment), _MF->madelung());
+          _bare_div_treatment, _MF->madelung());
     auto [nqpts, nImps, NP, nImpOrbs, nImpOrbs2] = B_qIPab.shape();
     nda::array<ComplexType, 2> BB_ab(nImpOrbs, nImpOrbs);
     nda::array<ComplexType, 2> BB_cd_conj(nImpOrbs, nImpOrbs);
@@ -2235,11 +2235,10 @@ namespace methods {
                                 nda::array<ComplexType, 5> &W_wcdab,
                                 const nda::array<ComplexType, 5> &B_qIPab,
                                 const nda::array<ComplexType, 1> &eps_inv_head) {
-    app_log(1, "  Treatment of long-wavelength divergence in W: {}", div_enum_to_string(_div_treatment));
-    auto div_string = div_enum_to_string(_div_treatment);
-    if (div_string == "ignore_g0") {
+    app_log(1, "  Treatment of long-wavelength divergence in W: {}", _div_treatment);
+    if (_div_treatment == "ignore_g0") {
       return;
-    } else if (div_string.find("gygi") != std::string::npos) {
+    } else if (_div_treatment.find("gygi") != std::string::npos) {
       app_log(1, "    - madelung = {}", _MF->madelung());
 
       auto [nqpts, nImps, NP, nImpOrbs, nImpOrbs2] = B_qIPab.shape();
@@ -2261,7 +2260,7 @@ namespace methods {
             _MF->madelung() * eps_inv_head(n) * nda::blas::outer_product(BB_cd_conj_1D, BB_ab_1D);
       }
     } else {
-      utils::check(false, "Unsupported divergence treatment: {}", div_enum_to_string(_div_treatment));
+      utils::check(false, "Unsupported divergence treatment: {}", _div_treatment);
     }
     app_log(1, "");
   }

--- a/src/methods/embedding/embed_eri_t.cpp
+++ b/src/methods/embedding/embed_eri_t.cpp
@@ -219,7 +219,7 @@ namespace methods {
     } else {
       utils::check(false, "embed_eri_t.cpp::compute_downfolded_coulomb_tensors_impl: downfold_2e logic fail: the input dataset {} does not exist!", greens_func_source);
     }
-    app_log(2, "Dataset check complete: input dataset {}/iter{} exists and is valid.\n", greens_func_source, greens_func_iteration);
+    app_log(2, "Dataset check complete: input dataset {}/iter{} is valid.\n", greens_func_source, greens_func_iteration);
 
     auto mpi = eri.mpi();
     const auto &proj_boson = mb_state.proj_boson.value();
@@ -237,7 +237,7 @@ namespace methods {
     if (write_to_hdf5) {
       app_log(1, "    - Output HDF5 group                       = {}/iter{}/downfolded_model", greens_func_source, greens_func_iteration);
       if (q_dependent_output)
-        app_log(1, "      Stored Q-dependent result               = {}", q_dependent_output);
+        app_log(1, "      Stored q-dependent result               = {}", q_dependent_output);
     }
     if (!proj_boson.C_file().empty())
       app_log(1, "  - Transformation matrices                   = {}", proj_boson.C_file());
@@ -277,15 +277,14 @@ namespace methods {
     // Enforce permutation symmetries if needed
     int nts_half = (ft.nt_b() % 2 == 0) ? ft.nt_b() / 2 : ft.nt_b() / 2 + 1;
     nda::array<ComplexType, 5> U_tabcd(nts_half, nImpOrbs, nImpOrbs, nImpOrbs, nImpOrbs);
+    ft.w_to_tau_PHsym(U_wabcd, U_tabcd);
     if (permut_symm != "none") {
       _Timer.start("DF_SYMM");
       apply_permut_symm(V_abcd, permut_symm, "bare interactions");
-      ft.w_to_tau_PHsym(U_wabcd, U_tabcd);
       apply_permut_symm(U_tabcd, permut_symm, "screened interactions");
       ft.tau_to_w_PHsym(U_tabcd, U_wabcd);
       _Timer.stop("DF_SYMM");
     }
-    ft.w_to_tau_PHsym(U_wabcd, U_tabcd);
     ft.check_leakage_PHsym(U_tabcd, imag_axes_ft::boson, std::addressof(mpi->comm), "Local screened interaction");
 
     // Print summary
@@ -2207,7 +2206,8 @@ namespace methods {
   template<THC_ERI thc_t, nda::ArrayOfRank<5> B_t>
   void embed_eri_t::V_div_correction(nda::array<ComplexType, 4> &V_cdab,
                                 const B_t &B_qIPab, thc_t &thc) {
-    if (_bare_div_treatment == ignore_g0) {
+    auto div_string = div_enum_to_string(_bare_div_treatment);
+    if (div_string == "ignore_g0") {
       app_log(1, "No finite-size correction for the long-wavelength divergence in "
                  "the local bare V. ");
       return;
@@ -2236,9 +2236,10 @@ namespace methods {
                                 const nda::array<ComplexType, 5> &B_qIPab,
                                 const nda::array<ComplexType, 1> &eps_inv_head) {
     app_log(1, "  Treatment of long-wavelength divergence in W: {}", div_enum_to_string(_div_treatment));
-    if (_div_treatment == ignore_g0) {
+    auto div_string = div_enum_to_string(_div_treatment);
+    if (div_string == "ignore_g0") {
       return;
-    } else if (_div_treatment == gygi or _div_treatment == gygi_extrplt or _div_treatment==gygi_extrplt_2d) {
+    } else if (div_string.find("gygi") != std::string::npos) {
       app_log(1, "    - madelung = {}", _MF->madelung());
 
       auto [nqpts, nImps, NP, nImpOrbs, nImpOrbs2] = B_qIPab.shape();

--- a/src/methods/embedding/embed_eri_t.h
+++ b/src/methods/embedding/embed_eri_t.h
@@ -39,7 +39,6 @@
 #include "methods/mb_state/mb_state.hpp"
 #include "methods/embedding/permut_symm.hpp"
 #include "methods/ERI/detail/concepts.hpp"
-#include "methods/ERI/div_treatment_e.hpp"
 #include "methods/GW/gw_t.h"
 #include "methods/embedding/dc_utilities.hpp"
 #include "methods/SCF/scf_common.hpp"
@@ -74,21 +73,21 @@ namespace methods {
 
   public:
     embed_eri_t(mf::MF &MF,
-                div_treatment_e div = gygi, div_treatment_e bare_div = gygi,
+                std::string div = "gygi", std::string bare_div = "gygi",
                 std::string output_type = "default"):
     _context(MF.mpi()), _MF(std::addressof(MF)),
     _div_treatment(div), _bare_div_treatment(bare_div), _Timer(),
     _output_type(output_type) {
 
-      if (_MF->nkpts_ibz() == 1 and _div_treatment != ignore_g0) {
+      if (_MF->nkpts_ibz() == 1 and _div_treatment != "ignore_g0") {
         app_log(2, " embed_eri_t: nkpts_ibz == 1 while div_treatment != ignore. Will take div_treatment = ignore_g0 anyway!");
-        _div_treatment = ignore_g0;
+        _div_treatment = "ignore_g0";
       }
 
-      if (_bare_div_treatment!=ignore_g0 and _bare_div_treatment!=gygi) {
+      if (_bare_div_treatment!="ignore_g0" and _bare_div_treatment!="gygi") {
         app_log(2, " embed_eri_t: bare_div_treatment only supports \"ignore_g0\" and \"gygi\". "
                    " coqui will take bare_div_treatment = \"gygi\" instead.");
-        _bare_div_treatment = gygi;
+        _bare_div_treatment = "gygi";
       }
     }
 
@@ -309,15 +308,15 @@ namespace methods {
     std::shared_ptr<mpi_context_t> _context;
     mf::MF* _MF = nullptr;
 
-    div_treatment_e _div_treatment;
-    div_treatment_e _bare_div_treatment;
+    std::string _div_treatment;
+    std::string _bare_div_treatment;
     utils::TimerManager _Timer;
 
     std::string _output_type = "default";
 
   public:
     mf::MF* MF() const { return _MF; }
-    const div_treatment_e& div_treatment() const { return _div_treatment; }
+    const std::string& div_treatment() const { return _div_treatment; }
 
   }; // embed_eri_t
 } // methods

--- a/src/methods/embedding/embed_t.h
+++ b/src/methods/embedding/embed_t.h
@@ -36,7 +36,6 @@
 
 #include "utilities/mpi_context.h"
 #include "mean_field/MF.hpp"
-#include "methods/ERI/div_treatment_e.hpp"
 #include "methods/SCF/mb_solver_t.h"
 #include "methods/mb_state/mb_state.hpp"
 #include "numerics/imag_axes_ft/iaft_utils.hpp"
@@ -107,7 +106,7 @@ namespace methods {
     template<THC_ERI thc_t>
     void hf_downfolding(std::string outdir, std::string prefix,
                         thc_t& eri, imag_axes_ft::IAFT &ft,
-                        bool force_real, div_treatment_e hf_div_treatment=gygi);
+                        bool force_real, std::string hf_div_treatment="gygi");
 
 
     void add_Vhf_correction(MBState &mb_state);
@@ -202,7 +201,7 @@ namespace methods {
     template<THC_ERI thc_t>
     void downfold_hf_impl(std::string prefix,
                           thc_t& eri, imag_axes_ft::IAFT &ft,
-                          bool force_real, div_treatment_e hf_div_treatment=gygi);
+                          bool force_real, std::string hf_div_treatment="gygi");
 
     auto double_counting_hf_bare(h5::group &gh5_dc, h5::group &gh5_V, 
                                  long dc_iter, std::string dc_src_grp,

--- a/src/methods/embedding/tests/test_embed.cpp
+++ b/src/methods/embedding/tests/test_embed.cpp
@@ -64,8 +64,8 @@ namespace bdft_tests {
         std::shared_ptr<mf::MF> &mf, std::string wannier_file, std::string dc_type,
         std::array<double, 6> &refs, double eps) {
       solvers::hf_t hf;
-      solvers::gw_t gw(&ft, string_to_div_enum("gygi"), coqui_prefix);
-      solvers::scr_coulomb_t scr_eri(&ft, "rpa", string_to_div_enum("gygi"));
+      solvers::gw_t gw(&ft, "gygi_smallest_q", coqui_prefix);
+      solvers::scr_coulomb_t scr_eri(&ft, "rpa", "gygi_smallest_q");
       simple_dyson dyson(mf.get(), &ft);
       thc_reader_t thc(mf, make_thc_reader_ptree(mf->nbnd()*20, "", "incore", "", "bdft",
                                                  1e-10, mf->ecutrho(), 1, 1024));
@@ -81,7 +81,7 @@ namespace bdft_tests {
       pt.put("permut_symm", true);
       pt.put("force_real", true);
       pt.put("greens_func_source", "mf");
-      embed_eri_t embed_2e(*mf, string_to_div_enum("gygi"));
+      embed_eri_t embed_2e(*mf, "gygi_smallest_q");
       embed_2e.downfolding_crpa(thc, mb_state, pt, "crpa");
 
       // Single-shot GW based on DFT Green's function
@@ -166,8 +166,8 @@ TEST_CASE("downfold_1e_mb_qp", "[methods][embed][df_1e]") {
         std::shared_ptr<mf::MF> &mf, std::string wannier_file, std::string dc_type,
         std::array<double, 12> &refs, double eps) {
       solvers::hf_t hf;
-      solvers::gw_t gw(&ft, string_to_div_enum("gygi"), coqui_prefix);
-      solvers::scr_coulomb_t scr_eri(&ft, "rpa", string_to_div_enum("gygi"));
+      solvers::gw_t gw(&ft, "gygi_smallest_q", coqui_prefix);
+      solvers::scr_coulomb_t scr_eri(&ft, "rpa", "gygi_smallest_q");
       simple_dyson dyson(mf.get(), &ft);
       thc_reader_t thc(mf, make_thc_reader_ptree(0, "", "incore", "", "bdft",
                                                  1e-8, mf->ecutrho(), 1, 1024, 10, 0.4));
@@ -182,7 +182,7 @@ TEST_CASE("downfold_1e_mb_qp", "[methods][embed][df_1e]") {
       pt.put("permut_symm", true);
       pt.put("force_real", true);
       pt.put("greens_func_source", "mf");
-      embed_eri_t embed_2e(*mf, string_to_div_enum("gygi"));
+      embed_eri_t embed_2e(*mf, "gygi_smallest_q");
       embed_2e.downfolding_crpa(thc, mb_state, pt, "crpa");
 
       [[maybe_unused]] auto [e_hf, e_corr] = scf_loop(mb_state, dyson, eri, ft,
@@ -401,6 +401,7 @@ TEST_CASE("downfold_1e_mb_qp", "[methods][embed][df_1e]") {
       pt.put("wannier_file", wannier_file);
       pt.put("greens_func_source", "mf");
       pt.put("screen_type", "crpa");
+      pt.put("div_treatment", "gygi_smallest_q");
       pt.put("beta", 1000.0);
       pt.put("wmax", 3.0);
       auto [Vloc, Wloc_w] = downfold_coulomb_with_projector_from_h5(thc, pt);
@@ -470,7 +471,7 @@ TEST_CASE("downfold_1e_mb_qp", "[methods][embed][df_1e]") {
       pt.put("permut_symm", true);
       pt.put("force_real", true);
       pt.put("greens_func_source", "");
-      embed_eri_t embed_2e(*mf, string_to_div_enum("gygi"));
+      embed_eri_t embed_2e(*mf, "gygi_smallest_q");
       embed_2e.downfolding_crpa(thc, mb_state, pt, "crpa");
       mpi->comm.barrier();
 
@@ -560,7 +561,7 @@ TEST_CASE("downfold_1e_mb_qp", "[methods][embed][df_1e]") {
       std::string greens_func_source = "scf";
       long greens_func_iteration = 0;
 
-      embed_eri_t embed_2e(*mf, string_to_div_enum("gygi"));
+      embed_eri_t embed_2e(*mf, "gygi_smallest_q");
 
       // --- RPA ---
       std::string screen_type_rpa = "rpa";
@@ -657,7 +658,7 @@ TEST_CASE("downfold_1e_mb_qp", "[methods][embed][df_1e]") {
       pt.put("force_real", true);
       // FIXME ?
       pt.put("greens_func_source", "mf");
-      embed_eri_t embed_2e(*mf, string_to_div_enum("gygi"));
+      embed_eri_t embed_2e(*mf, "gygi_smallest_q");
       embed_2e.downfolding_edmft(thc, mb_state, pt, "gw_edmft");
       mpi->comm.barrier();
 
@@ -728,8 +729,8 @@ TEST_CASE("downfold_1e_mb_qp", "[methods][embed][df_1e]") {
       std::string prefix = "coqui";
       imag_axes_ft::IAFT ft(1000.0, 1.2, imag_axes_ft::ir_source, "high", true);
       solvers::hf_t hf;
-      solvers::gw_t gw(&ft, string_to_div_enum("gygi"), prefix);
-      solvers::scr_coulomb_t scr_eri(&ft, "rpa", string_to_div_enum("gygi"));
+      solvers::gw_t gw(&ft, "gygi_smallest_q", prefix);
+      solvers::scr_coulomb_t scr_eri(&ft, "rpa", "gygi_smallest_q");
       simple_dyson dyson(mf.get(), &ft);
       thc_reader_t thc(mf, make_thc_reader_ptree(mf->nbnd()*20, "", "incore", "", "bdft",
                                                  1e-10, mf->ecutrho(), 1, 1024));
@@ -745,7 +746,7 @@ TEST_CASE("downfold_1e_mb_qp", "[methods][embed][df_1e]") {
         pt.put("permut_symm", true);
         pt.put("force_real", false);
         pt.put("greens_func_source", "");
-        embed_eri_t embed_2e(*mf, string_to_div_enum("gygi"), string_to_div_enum("gygi"));
+        embed_eri_t embed_2e(*mf, "gygi_smallest_q");
         embed_2e.downfolding_crpa(thc, mb_state, pt, "crpa", "none", 1e-8);
         mpi->comm.barrier();
 
@@ -774,13 +775,12 @@ TEST_CASE("downfold_1e_mb_qp", "[methods][embed][df_1e]") {
         pt.put("permut_symm", true);
         pt.put("force_real", false);
         pt.put("greens_func_source", "");
-        embed_eri_t embed_2e(*mf, string_to_div_enum("gygi"),
-                             string_to_div_enum("gygi"), "model_static");
+        embed_eri_t embed_2e(*mf, "gygi_smallest_q", "gygi", "model_static");
         embed_2e.downfolding_crpa(thc, mb_state, pt, "bare", "none", 1e-8);
         mpi->comm.barrier();
 
         embed_t embed(*mf, wannier_file, true);
-        embed.hf_downfolding("./", prefix + ".bare", thc, ft, false, string_to_div_enum("gygi"));
+        embed.hf_downfolding("./", prefix + ".bare", thc, ft, false, "gygi");
         mpi->comm.barrier();
       }
 
@@ -794,13 +794,12 @@ TEST_CASE("downfold_1e_mb_qp", "[methods][embed][df_1e]") {
         pt.put("permut_symm", true);
         pt.put("force_real", false);
         pt.put("greens_func_source", "");
-        embed_eri_t embed_2e(*mf, string_to_div_enum("gygi"),
-                             string_to_div_enum("gygi"), "model_static");
+        embed_eri_t embed_2e(*mf, "gygi_smallest_q", "gygi", "model_static");
         embed_2e.downfolding_crpa(thc, mb_state, pt, "bare", "cholesky", 1e-8);
         mpi->comm.barrier();
 
         embed_t embed(*mf, wannier_file, true);
-        embed.hf_downfolding("./", prefix + ".bare.chol", thc, ft, false, string_to_div_enum("gygi"));
+        embed.hf_downfolding("./", prefix + ".bare.chol", thc, ft, false, "gygi");
         mpi->comm.barrier();
       }
 
@@ -814,8 +813,7 @@ TEST_CASE("downfold_1e_mb_qp", "[methods][embed][df_1e]") {
         pt.put("permut_symm", true);
         pt.put("force_real", false);
         pt.put("greens_func_source", "");
-        embed_eri_t embed_2e(*mf, string_to_div_enum("gygi"),
-                             string_to_div_enum("gygi"), "model_static");
+        embed_eri_t embed_2e(*mf, "gygi_smallest_q", "gygi", "model_static");
         embed_2e.downfolding_crpa(thc, mb_state, pt, "crpa", "cholesky", 1e-8);
         mpi->comm.barrier();
 

--- a/src/methods/scr_coulomb/scr_coulomb_t.cpp
+++ b/src/methods/scr_coulomb/scr_coulomb_t.cpp
@@ -345,12 +345,12 @@ namespace solvers {
 
       if (!mb_state.sPi_imp_wabcd or !mb_state.sPi_dc_wabcd) {
         app_log(1, "");
-        app_log(1, "╔══════════════════════════════════════════════════════════╗");
-        app_log(1, "║ [ NOTE ]                                                 ║");
-        app_log(1, "║ Screening type is set to \"edmft\", but no local           ║");
-        app_log(1, "║ polarization corrections were found or provided.         ║");
-        app_log(1, "║ CoQui will proceed assuming zero correction.             ║");
-        app_log(1, "╚══════════════════════════════════════════════════════════╝\n");
+        app_log(1, "╔══════════════════════════════════════════════════════╗");
+        app_log(1, "║ [ NOTE ]                                             ║");
+        app_log(1, "║ Screening type is set to \"edmft\", but local        ║");
+        app_log(1, "║ polarization corrections were not found or provided. ║");
+        app_log(1, "║ CoQui will proceed assuming zero correction.         ║");
+        app_log(1, "╚══════════════════════════════════════════════════════╝\n");
 
       } else {
         auto &proj_boson = mb_state.proj_boson.value();

--- a/src/methods/scr_coulomb/scr_coulomb_t.cpp
+++ b/src/methods/scr_coulomb/scr_coulomb_t.cpp
@@ -32,7 +32,7 @@ namespace solvers {
 
   scr_coulomb_t::scr_coulomb_t(const imag_axes_ft::IAFT *ft,
                                std::string screen_type,
-                               div_treatment_e div):
+                               std::string div):
     _ft(ft), _screen_type(screen_type),
     _div_treatment(div), _Timer() {
 
@@ -73,7 +73,7 @@ namespace solvers {
                "  Divergent treatment at q->0   = {}\n",
             _screen_type, thc.MF()->nbnd(), thc.Np(),
             thc.MF()->nkpts(), thc.MF()->nkpts_ibz(),
-            div_enum_to_string(_div_treatment));
+          _div_treatment);
     _ft->metadata_log();
 
     utils::check(thc.mpi() == mb_state.mpi,

--- a/src/methods/scr_coulomb/scr_coulomb_t.cpp
+++ b/src/methods/scr_coulomb/scr_coulomb_t.cpp
@@ -306,9 +306,9 @@ namespace solvers {
       app_log(1, "");
       app_log(1, "╔══════════════════════════════════════════════════════════╗");
       app_log(1, "║ [ NOTE ]                                                 ║");
-      app_log(1, "║ Screening type is set to non-\"edmft\" type, but local     ║");
-      app_log(1, "║ polarizabilities were found or provided. The calculation ║");
-      app_log(1, "║ will simply ignoring the polarizability correction.      ║");
+      app_log(1, "║ Screening type is set to \"non-edmft\" type, but local     ║");
+      app_log(1, "║ polarization corrections were found or provided.         ║");
+      app_log(1, "║ CoQui will ignore the corrections.                       ║");
       app_log(1, "╚══════════════════════════════════════════════════════════╝\n");
     }
     utils::check(mb_state.sG_tskij.has_value(),
@@ -348,8 +348,8 @@ namespace solvers {
         app_log(1, "╔══════════════════════════════════════════════════════════╗");
         app_log(1, "║ [ NOTE ]                                                 ║");
         app_log(1, "║ Screening type is set to \"edmft\", but no local           ║");
-        app_log(1, "║ polarizabilities were found or provided. The calculation ║");
-        app_log(1, "║ will proceed assuming zero polarizability correction.    ║");
+        app_log(1, "║ polarization corrections were found or provided.         ║");
+        app_log(1, "║ CoQui will proceed assuming zero correction.             ║");
         app_log(1, "╚══════════════════════════════════════════════════════════╝\n");
 
       } else {

--- a/src/methods/scr_coulomb/scr_coulomb_t.h
+++ b/src/methods/scr_coulomb/scr_coulomb_t.h
@@ -38,7 +38,6 @@
 #include "numerics/imag_axes_ft/iaft_utils.hpp"
 #include "methods/mb_state/mb_state.hpp"
 #include "methods/ERI/detail/concepts.hpp"
-#include "methods/ERI/div_treatment_e.hpp"
 
 namespace methods {
 namespace solvers {
@@ -85,7 +84,7 @@ namespace solvers {
     scr_coulomb_t(
         const imag_axes_ft::IAFT *ft,
         std::string screen_type,
-        div_treatment_e div = gygi);
+      std::string div = "gygi");
 
     scr_coulomb_t(scr_coulomb_t const&) = default;
     scr_coulomb_t(scr_coulomb_t &&) = default;
@@ -259,7 +258,7 @@ namespace solvers {
 
     std::string _screen_type = "";
 
-    div_treatment_e _div_treatment;
+    std::string _div_treatment;
     utils::TimerManager _Timer;
 
     // optional container for screened interaction
@@ -268,7 +267,7 @@ namespace solvers {
     std::optional<nda::array<ComplexType, 1> > _eps_inv_head;
 
   public:
-    div_treatment_e div_treatment() const { return _div_treatment; }
+    std::string div_treatment() const { return _div_treatment; }
     std::string& screen_type() { return _screen_type; };
     std::string screen_type() const { return _screen_type; };
 

--- a/src/python/dmft/bath_fit.py
+++ b/src/python/dmft/bath_fit.py
@@ -189,6 +189,51 @@ def fit_u_weiss(u_weiss_iw, ir_kernel, causal_params):
     return u_iw_fit
 
 
+def poly_lstsq_extrapolate(x_data, y_data, fit_order=1, x_target=0.0):
+    """
+    Fit y(x) with a polynomial of arbitrary order using least squares,
+    then evaluate the fitted polynomial at x_target.
+
+    Parameters:
+        x_data (array-like): 1D sample locations with shape (nsample,).
+        y_data (numpy.ndarray): Sample values with shape (nsample, ...).
+                                The first axis must match x_data length.
+        fit_order (int): Polynomial order.
+        x_target (float): Extrapolation/evaluation point.
+
+    Returns:
+        numpy.ndarray: Extrapolated value at x_target with shape y_data.shape[1:].
+    """
+    x_data = np.asarray(x_data, dtype=np.float64)
+    y_data = np.asarray(y_data)
+
+    if x_data.ndim != 1:
+        raise ValueError("x_data must be a 1D array.")
+    if y_data.ndim < 1:
+        raise ValueError("y_data must have at least 1 dimension.")
+    if y_data.shape[0] != x_data.shape[0]:
+        raise ValueError("y_data.shape[0] must match x_data.shape[0].")
+    if fit_order < 0:
+        raise ValueError("fit_order must be non-negative.")
+    if x_data.shape[0] < fit_order + 1:
+        raise ValueError(
+            f"Need at least fit_order+1={fit_order+1} samples, got {x_data.shape[0]}."
+        )
+
+    # Vandermonde matrix with ascending powers: [1, x, x^2, ...]
+    vandermonde = np.vander(x_data, N=fit_order + 1, increasing=True)
+
+    # Flatten all trailing dimensions, solve independent least-squares fits in batch
+    y_matrix = y_data.reshape(y_data.shape[0], -1)
+    coeffs, *_ = np.linalg.lstsq(vandermonde, y_matrix, rcond=None)
+
+    # Evaluate polynomial at x_target
+    x_powers = np.power(float(x_target), np.arange(fit_order + 1, dtype=np.float64))
+    y_target = (x_powers[:, None] * coeffs).sum(axis=0)
+
+    return y_target.reshape(y_data.shape[1:])
+
+
 def apply_w0_regularization(A_iw, iw_mesh_b, w0_regularization, target_name):
     """
     Apply regularization to the zero-frequency component of the bosonic Green's function.
@@ -223,13 +268,38 @@ def apply_w0_regularization(A_iw, iw_mesh_b, w0_regularization, target_name):
 
     elif w0_regularization == "linear_extrapolate":
 
-        # For metallic case, set A(iw=0) to a small positive value
+        # For metallic case, set A(iw=0) by linear extrapolation using A(iw1) and A(iw2)
         mpi.report(f"  --> Extrapolating {target_name} at w=0 using linear extrapolation at iw1 and iw2.")
         zero_index = np.where(iw_mesh_b == 0.0)[0][0]
-        slope = (A_iw[zero_index + 1] - A_iw[zero_index + 2]) / (np.abs(iw_mesh_b[zero_index + 1]) - np.abs(iw_mesh_b[zero_index + 2]))
-        A_iw[zero_index] = A_iw[zero_index + 1] - slope * np.abs(iw_mesh_b[zero_index + 1])
+        if zero_index + 2 >= iw_mesh_b.shape[0]:
+            raise ValueError(
+                f"linear_extrapolate requires at least 2 positive Matsubara points after w=0 for {target_name}."
+            )
+        
+        x_data = np.abs(iw_mesh_b[zero_index + 1:zero_index + 3])
+        y_data = A_iw[zero_index + 1:zero_index + 3]
+        A_iw[zero_index] = poly_lstsq_extrapolate(x_data, y_data, fit_order=1, x_target=0.0)
+        #slope = (A_iw[zero_index + 1] - A_iw[zero_index + 2]) / (np.abs(iw_mesh_b[zero_index + 1]) - np.abs(iw_mesh_b[zero_index + 2]))
+        #A_iw[zero_index] = A_iw[zero_index + 1] - slope * np.abs(iw_mesh_b[zero_index + 1])
+
+    elif w0_regularization == "quadratic_extrapolate":
+
+        # Set A(iw=0) by quadratic extrapolation using A(iw1), A(iw2), and A(iw3)
+        mpi.report(f"  --> Extrapolating {target_name} at w=0 using quadratic extrapolation at iw1, iw2, and iw3.")
+        zero_index = np.where(iw_mesh_b == 0.0)[0][0]
+        if zero_index + 3 >= iw_mesh_b.shape[0]:
+            raise ValueError(
+                f"quadratic_extrapolate requires at least 3 positive Matsubara points after w=0 for {target_name}."
+            )
+
+        x_data = np.abs(iw_mesh_b[zero_index + 1:zero_index + 4])
+        y_data = A_iw[zero_index + 1:zero_index + 4]
+        A_iw[zero_index] = poly_lstsq_extrapolate(x_data, y_data, fit_order=2, x_target=0.0)
 
     else:
-        raise ValueError(f"Invalid w0_regularization option: {w0_regularization}. Use 'flatten' or 'linear_extrapolate'.")
+        raise ValueError(
+            f"Invalid w0_regularization option: {w0_regularization}. "
+            "Use 'flatten', 'linear_extrapolate', or 'quadratic_extrapolate'."
+        )
 
     return A_iw

--- a/src/python/dmft/bath_fit.py
+++ b/src/python/dmft/bath_fit.py
@@ -265,41 +265,30 @@ def apply_w0_regularization(A_iw, iw_mesh_b, w0_regularization, target_name):
         mpi.report(f"  --> Flattening {target_name} at w=0.")
         zero_index = np.where(iw_mesh_b == 0.0)[0][0]
         A_iw[zero_index] = A_iw[zero_index + 1]
-
-    elif w0_regularization == "linear_extrapolate":
-
-        # For metallic case, set A(iw=0) by linear extrapolation using A(iw1) and A(iw2)
-        mpi.report(f"  --> Extrapolating {target_name} at w=0 using linear extrapolation at iw1 and iw2.")
-        zero_index = np.where(iw_mesh_b == 0.0)[0][0]
-        if zero_index + 2 >= iw_mesh_b.shape[0]:
+    
+    elif w0_regularization[:18] == "extrapolate_order_":
+   
+        try:
+            order = int(w0_regularization[18:])
+        except ValueError:
             raise ValueError(
-                f"linear_extrapolate requires at least 2 positive Matsubara points after w=0 for {target_name}."
+                f"Invalid extrapolate_order value: {w0_regularization[18:]}. Must be an integer."
             )
-        
-        x_data = np.abs(iw_mesh_b[zero_index + 1:zero_index + 3])
-        y_data = A_iw[zero_index + 1:zero_index + 3]
-        A_iw[zero_index] = poly_lstsq_extrapolate(x_data, y_data, fit_order=1, x_target=0.0)
-        #slope = (A_iw[zero_index + 1] - A_iw[zero_index + 2]) / (np.abs(iw_mesh_b[zero_index + 1]) - np.abs(iw_mesh_b[zero_index + 2]))
-        #A_iw[zero_index] = A_iw[zero_index + 1] - slope * np.abs(iw_mesh_b[zero_index + 1])
-
-    elif w0_regularization == "quadratic_extrapolate":
-
-        # Set A(iw=0) by quadratic extrapolation using A(iw1), A(iw2), and A(iw3)
-        mpi.report(f"  --> Extrapolating {target_name} at w=0 using quadratic extrapolation at iw1, iw2, and iw3.")
+        mpi.report(f"  --> Extrapolating {target_name} at w = 0 as an O(w²) polynomial of order {order}.")
         zero_index = np.where(iw_mesh_b == 0.0)[0][0]
-        if zero_index + 3 >= iw_mesh_b.shape[0]:
+        if zero_index + order >= iw_mesh_b.shape[0]:
             raise ValueError(
-                f"quadratic_extrapolate requires at least 3 positive Matsubara points after w=0 for {target_name}."
+                f"extrapolate_order_{order} requires at least {order} positive Matsubara points after w=0 for {target_name}."
             )
 
-        x_data = np.abs(iw_mesh_b[zero_index + 1:zero_index + 4])
-        y_data = A_iw[zero_index + 1:zero_index + 4]
-        A_iw[zero_index] = poly_lstsq_extrapolate(x_data, y_data, fit_order=2, x_target=0.0)
+        x_data = np.array([np.abs(iw)**2 for iw in iw_mesh_b[zero_index + 1:zero_index + 2 + order]])
+        y_data = A_iw[zero_index + 1:zero_index + 2 + order]
+        A_iw[zero_index] = poly_lstsq_extrapolate(x_data, y_data, fit_order=order, x_target=0.0)
 
     else:
         raise ValueError(
             f"Invalid w0_regularization option: {w0_regularization}. "
-            "Use 'flatten', 'linear_extrapolate', or 'quadratic_extrapolate'."
+            "Use 'flatten' or 'extrapolate_order_<n>'."
         )
 
     return A_iw

--- a/src/python/dmft/bath_fit.py
+++ b/src/python/dmft/bath_fit.py
@@ -257,7 +257,7 @@ def apply_w0_regularization(A_iw, iw_mesh_b, w0_regularization, target_name):
     Returns:
         numpy.ndarray: The modified bosonic Green's function with regularized iw = 0 component.
     """
-    mpi.report(f"Applying {w0_regularization} w=0 regularization for {target_name} before causal projection:")
+    mpi.report(f"Applying w=0 regularization for {target_name} before causal projection:")
     
     if w0_regularization == "flatten":
         
@@ -276,9 +276,10 @@ def apply_w0_regularization(A_iw, iw_mesh_b, w0_regularization, target_name):
             )
         mpi.report(f"  --> Extrapolating {target_name} at w = 0 as an O(w²) polynomial of order {order}.")
         zero_index = np.where(iw_mesh_b == 0.0)[0][0]
-        if zero_index + order >= iw_mesh_b.shape[0]:
+        available_points = iw_mesh_b[zero_index+1:].shape[0]
+        if order+1 > available_points:
             raise ValueError(
-                f"extrapolate_order_{order} requires at least {order} positive Matsubara points after w=0 for {target_name}."
+                f"extrapolate_order_{order} requires at least {order+1} positive Matsubara points after w=0 for {target_name}."
             )
 
         x_data = np.array([np.abs(iw)**2 for iw in iw_mesh_b[zero_index + 1:zero_index + 2 + order]])

--- a/src/python/dmft/ctseg/ctseg_utils.py
+++ b/src/python/dmft/ctseg/ctseg_utils.py
@@ -118,7 +118,7 @@ def post_process_pi(solver, degenerate_blk=None, output_in_4idx=False,
     # U(iw) in density-density basis
     D0_iijj = D0_iw[:n_orb, n_orb:2*n_orb]
     # screening J if non-zero
-    D0_ijij = D0_iijj - D0_iw[:n_orb, 0:n_orb]
+    D0_ijij = D0_iijj - D0_iw[:n_orb, :n_orb]
 
     # Vijkl is the full 4-index tensor without the block structure in TRIQS's notation
     Vijkl = extract_u_tensor_from_h_int(h_int=solver.h_int, gf_struct=solver.gf_struct, return_4idx=True)
@@ -344,6 +344,7 @@ def extract_u_tensor_from_h_int(h_int, gf_struct, return_4idx=False):
     """
     from triqs.operators.util.extractors import extract_U_dict2, dict_to_matrix
 
+    # extract the density-density Coulomb matrix U_dd
     U_dd = dict_to_matrix(extract_U_dict2(h_int), gf_struct=gf_struct)
     if not return_4idx:
         return U_dd

--- a/src/python/dmft/dmft_state.py
+++ b/src/python/dmft/dmft_state.py
@@ -293,7 +293,8 @@ class DMFTState(object):
         mpi.barrier()
 
 
-    def damp_impurity_results(self, solver_chkpt, mixing=0.7, *, impurity_indices=None):
+    def damp_impurity_results(self, solver_chkpt, mixing=0.7, *, impurity_indices=None, 
+                              mix_in_first_iter=False):
         assert self.iteration >= 0, "damp_impurity_results: Iteration must be greater than 0"
 
         if impurity_indices is not None:
@@ -301,12 +302,13 @@ class DMFTState(object):
         else:
             impurity_indices = np.arange(len(self.solver_results))
 
-        #if self.iteration == 0: # no damping in the first iteration
-        #    return
+        if self.iteration == 0 and not mix_in_first_iter: # no damping in the first iteration
+            mpi.report("Skipping damping the impurity results in the first iteration.\n")
+            return
 
-        mpi.report(f"Damping impurity results for impurities {impurity_indices}\n")
-        if self.iteration == 0:
+        if self.iteration == 0 and mix_in_first_iter:
             # first iteration: mix impurity results with the dc terms in the first iteration 
+            mpi.report(f"Mixing impurity results with DC terms for impurities {impurity_indices}\n")
             for idx, imp_idx in enumerate(impurity_indices):
                 res = self.solver_results[imp_idx]
                 imp_key = ['Sigma_infty', 'Sigma_iw_data', 'Pi_iw_data']
@@ -318,7 +320,8 @@ class DMFTState(object):
                         raise KeyError(f"Missing key '{dc}' for impurity {imp_idx} during damping.")
                     _mix_into(res[imp], res[dc], mixing)
             return
-
+        
+        mpi.report(f"Mixing impurity results with the previous iteration for impurities {impurity_indices}\n")
         solver_results_prev = dmft_io.read_impurity_chkpt(
             solver_chkpt, self.iteration-1, read="results", impurity_indices=impurity_indices
         )

--- a/src/python/dmft/dmft_state.py
+++ b/src/python/dmft/dmft_state.py
@@ -301,24 +301,23 @@ class DMFTState(object):
         else:
             impurity_indices = np.arange(len(self.solver_results))
 
-        if self.iteration == 0: # no damping in the first iteration
-            return
+        #if self.iteration == 0: # no damping in the first iteration
+        #    return
 
         mpi.report(f"Damping impurity results for impurities {impurity_indices}\n")
-        # Preserve the original first-iteration damping logic for reference, but keep it disabled.
-        #if self.iteration == 0:
-        #    # first iteration: mix with dc terms
-        #    for idx, imp_idx in enumerate(impurity_indices):
-        #        res = self.solver_results[imp_idx]
-        #        imp_key = ['Sigma_infty', 'Sigma_iw_data', 'Pi_iw_data']
-        #        dc_key  = ['Sigma_infty_dc', 'Sigma_iw_dc_data', 'Pi_iw_dc_data']
-        #        for (imp, dc) in zip(imp_key, dc_key):
-        #            if imp not in res:
-        #                raise KeyError(f"Missing key '{imp}' for impurity {imp_idx} during damping.")
-        #            if dc not in res:
-        #                raise KeyError(f"Missing key '{dc}' for impurity {imp_idx} during damping.")
-        #            _mix_into(res[imp], res[dc], mixing)
-        #    return
+        if self.iteration == 0:
+            # first iteration: mix impurity results with the dc terms in the first iteration 
+            for idx, imp_idx in enumerate(impurity_indices):
+                res = self.solver_results[imp_idx]
+                imp_key = ['Sigma_infty', 'Sigma_iw_data', 'Pi_iw_data']
+                dc_key  = ['Sigma_infty_dc', 'Sigma_iw_dc_data', 'Pi_iw_dc_data']
+                for (imp, dc) in zip(imp_key, dc_key):
+                    if imp not in res:
+                        raise KeyError(f"Missing key '{imp}' for impurity {imp_idx} during damping.")
+                    if dc not in res:
+                        raise KeyError(f"Missing key '{dc}' for impurity {imp_idx} during damping.")
+                    _mix_into(res[imp], res[dc], mixing)
+            return
 
         solver_results_prev = dmft_io.read_impurity_chkpt(
             solver_chkpt, self.iteration-1, read="results", impurity_indices=impurity_indices

--- a/src/python/dmft/dmft_state.py
+++ b/src/python/dmft/dmft_state.py
@@ -172,6 +172,7 @@ class DMFTState(object):
                 self.embedding['2e'] == other.embedding['2e']
         )
 
+    # TODO make_dmft_state without an existing coqui_h5. Directly take the IR parameters as input. 
     @classmethod
     def make_dmft_state(cls, coqui_h5, embedding_1e, embedding_2e,
                         wmax_imp=None, prec_imp=None, spin_average=False,
@@ -295,7 +296,7 @@ class DMFTState(object):
 
     def damp_impurity_results(self, solver_chkpt, mixing=0.7, *, impurity_indices=None, 
                               mix_in_first_iter=False):
-        assert self.iteration >= 0, "damp_impurity_results: Iteration must be greater than 0"
+        assert self.iteration >= 0, "damp_impurity_results: Current iteration must be a non-negative integer."
 
         if impurity_indices is not None:
             assert isinstance(impurity_indices, list), "impurity_indices should be a list of integers."

--- a/src/python/dmft/io.py
+++ b/src/python/dmft/io.py
@@ -17,12 +17,128 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==========================================================================
 """
-
+from copy import deepcopy
 import triqs.utility.mpi as mpi
 from h5 import HDFArchive
 import numpy as np
 
-from triqs.gf import Gf, make_gf_dlr, BlockGf, Block2Gf, MeshImFreq, MeshDLRImFreq
+
+def convert_gw_edmft_params(params_dict):
+    params = deepcopy(params_dict)
+
+    # Check if 'gw_edmft' key exists in params (new format)
+    if 'gw_edmft' not in params:
+       return params
+
+    # Extract the gw_edmft group
+    gw_edmft_group = params.pop('gw_edmft')
+
+    # Copy top-level gw_edmft settings
+    gw_edmft_params = {}
+    niter = gw_edmft_group.get('niter')
+    gw_iter_per_loop = gw_edmft_group.get('gw_iter_per_loop', 1)
+    edmft_iter_per_loop = gw_edmft_group.get('edmft_iter_per_loop', 1)
+    if niter is None:
+        raise KeyError("Missing 'niter' parameter to specify the total number of GW+EDMFT cycles.")
+    if not isinstance(niter, int) or niter <= 0:
+        raise ValueError("'niter' must be a positive integer.")
+    if not isinstance(gw_iter_per_loop, int) or gw_iter_per_loop < 0:
+        raise ValueError("'gw_iter_per_loop' must be a non-negative integer.")
+    if not isinstance(edmft_iter_per_loop, int) or edmft_iter_per_loop < 0:
+        raise ValueError("'edmft_iter_per_loop' must be a non-negative integer.")
+    if edmft_iter_per_loop == 0 and gw_iter_per_loop == 1:
+        # Current GW+EDMFT SC logic does not upfold the GW solution and write new `embed` data 
+        # if `gw_iter_per_loop` is 1 in order to save some memory in the checkpoint hdf5. 
+        # Here, we swap `niter` and `gw_iter_per_loop` to make sure `embed` data is updated in the checkpoint.  
+        gw_iter_per_loop = niter
+        niter = 1
+        if gw_iter_per_loop == 1:
+            raise ValueError("Invalid combination of iteration parameters:\n" \
+            "When fixing the EDMFT part of the workflow by setting `edmft_iter_per_loop` to 0, " \
+            "`gw_iter_per_loop` or `niter` must be greater than 1.")
+    
+    gw_edmft_params['niter'] = niter
+    gw_edmft_params['gw_iter_per_loop'] = gw_iter_per_loop
+    gw_edmft_params['edmft_iter_per_loop'] = edmft_iter_per_loop
+    
+    screen_type = gw_edmft_group.get('screen_type', 'gw_edmft_density')
+    div_treatment = gw_edmft_group.get('div_treatment', 'gygi')
+    outdir = gw_edmft_group.get('outdir', './')
+    prefix = gw_edmft_group.get('prefix', 'coqui')
+    restart = gw_edmft_group.get('restart', False)
+
+    # GW parameters
+    if 'gw' in gw_edmft_group:
+        gw_edmft_params['gw'] = gw_edmft_group.pop('gw')
+        gw_edmft_params['gw']['output'] = outdir+"/"+prefix
+        gw_edmft_params['gw']['restart'] = restart
+        gw_edmft_params['gw']['screen_type'] = screen_type
+        gw_edmft_params['gw']['niter'] = 1
+        gw_edmft_params['gw']['div_treatment'] = div_treatment
+        if 'iter_alg' in gw_edmft_params['gw']:
+            assert gw_edmft_params['gw']['iter_alg']['alg'] == 'damping', (
+                "Only \'damping\' iterative algorithm is supported in the GW part of the GW+EDMFT workflow at the moment."
+            )
+
+    # wloc parameters
+    gw_edmft_params['wloc'] = {'outdir': outdir, 'prefix': prefix, 'screen_type': screen_type, 
+                               'div_treatment': div_treatment, 'output_in_tau': True}
+    # gloc parameters
+    gw_edmft_params['gloc'] = {'outdir': outdir, 'prefix': prefix}
+    # embed parameters
+    gw_edmft_params['dmft_embed'] = {'outdir': outdir, 'prefix': prefix, 'corr_only': gw_edmft_group.get('corr_only', True)}
+
+    # Convert 'edmft' section to 'impurity' (with nested 'impurity' -> 'solver')
+    if 'edmft' not in gw_edmft_group:
+        raise KeyError("Missing 'edmft' section in 'gw_edmft' parameters to specify the EDMFT part of the workflow.")
+    edmft_section = gw_edmft_group.pop('edmft')
+    gw_edmft_params['impurity'] = {'restart': restart}
+  
+    # Convert 'impurity' (new) to 'solver' (old)
+    if 'impurity' in edmft_section:
+        solver_list = edmft_section.pop('impurity')
+        if not isinstance(solver_list, list):
+            solver_list = [solver_list]
+    
+        for solver_params in solver_list:
+            if solver_params.get('degenerate_blk'):
+                solver_params['degenerate_blk'] = [np.array(x) for x in solver_params['degenerate_blk']]
+
+        gw_edmft_params['impurity']['solver'] = solver_list
+
+    # Copy iter_alg if present
+    if 'iter_alg' in edmft_section:
+        assert edmft_section['iter_alg']['alg'] == 'damping', (
+            "Only \'damping\' iterative algorithm is supported in the EDMFT part of the GW+EDMFT workflow at the moment."
+        )
+        gw_edmft_params['impurity']['iter_alg'] = edmft_section.pop('iter_alg')
+
+    # Copy any remaining keys
+    gw_edmft_params['impurity']['chkpt_h5'] = edmft_section.get('chkpt_h5', outdir+"/"+prefix+".mbpt.h5")
+    for key, value in edmft_section.items():
+        gw_edmft_params['impurity'][key] = value
+
+    return gw_edmft_params
+
+
+# Need to be careful with non-ct-qmc solver
+def _normalize_solver_params_list(solver_params_list, comm_size):
+    """
+    Scale Monte-Carlo cycle counts by MPI communicator size.
+    """
+    assert isinstance(solver_params_list, list), "solver_params_list must be a list of dictionaries."
+    normalized_list = []
+    for solver_params in solver_params_list:
+        solver_params_norm = deepcopy(solver_params)
+
+        solver_params_norm['n_cycles'] = int(solver_params_norm['n_cycles']/comm_size)
+        mu_params = solver_params_norm.get('chemical_potential')
+        if mu_params and 'n_cycles' in mu_params.keys():
+            mu_params['n_cycles'] = int(mu_params['n_cycles']/comm_size)
+
+        normalized_list.append(solver_params_norm)
+
+    return normalized_list
 
 
 def print_title_box(name, box_width=19):

--- a/src/python/dmft/io.py
+++ b/src/python/dmft/io.py
@@ -24,12 +24,6 @@ import numpy as np
 
 from triqs.gf import Gf, make_gf_dlr, BlockGf, Block2Gf, MeshImFreq, MeshDLRImFreq
 
-def print_gw_edmft_banner():
-    # http://patorjk.com/software/taag/#p=display&f=Calvin+S&t=COQUI+GW%2BEDMFT&x=none&v=4&h=4&w=80&we=false
-    print("╔═╗╔═╗╔═╗ ╦ ╦╦  ╔═╗┬ ┬╔═╗┌┬┐┌┬┐┌─┐┌┬┐\n"
-          "║  ║ ║║═╬╗║ ║║  ║ ╦│││║╣  │││││├┤  │ \n"
-          "╚═╝╚═╝╚═╝╚╚═╝╩  ╚═╝└┴┘╚═╝─┴┘┴ ┴└   ┴ \n")
-
 
 def print_title_box(name, box_width=19):
     top_left = '╔'

--- a/src/python/dmft/scf_driver.py
+++ b/src/python/dmft/scf_driver.py
@@ -31,7 +31,7 @@ import coqui.dmft as coqui_dmft
 Hartree_eV = 27.211386245988
 
 
-def gw_edmft_loop(mf, thc, proj_info, embedding_1e, embedding_2e, 
+def gw_edmft_loop(mf, thc, proj_info, embedding_1e, 
                   niter, gw_iter_per_loop=1, edmft_iter_per_loop=1, 
                   inner_loop_alg=1, **gw_edmft_params):
     """
@@ -48,6 +48,11 @@ def gw_edmft_loop(mf, thc, proj_info, embedding_1e, embedding_2e,
         print(f"  GW iterations per GW+EDMFT cycle    = {gw_iter_per_loop}")
         print(f"  EDMFT iterations per GW+EDMFT cycle = {edmft_iter_per_loop}")
         print(f"    - Fix Gloc and Wloc during EDMFT iterations = {inner_loop_alg==2}\n")
+
+    embedding_2e = embedding_1e.make_2particle.make_spinless
+    if coqui_mpi.root():
+        print(embedding_1e.description(True))
+        print(embedding_2e.description(True))
 
     # deep copy to avoid any changes in gw_edmft_params affecting outside the function.
     gw_edmft_params = deepcopy(gw_edmft_params)

--- a/src/python/dmft/scf_driver.py
+++ b/src/python/dmft/scf_driver.py
@@ -31,16 +31,23 @@ import coqui.dmft as coqui_dmft
 Hartree_eV = 27.211386245988
 
 
-def gw_edmft_loop(mf, thc, proj_info, embedding_1e, embedding_2e,
-                  inner_num_iter, outer_num_iter, inner_loop_alg=1,
-                  **gw_edmft_params):
+def gw_edmft_loop(mf, thc, proj_info, embedding_1e, embedding_2e, 
+                  niter, gw_iter_per_loop=1, edmft_iter_per_loop=1, 
+                  inner_loop_alg=1, **gw_edmft_params):
     """
     GW+EDMFT self-consistency loop
     :return:
     """
     coqui_mpi = mf.mpi()
     if coqui_mpi.root():
-        coqui_dmft.print_gw_edmft_banner()
+        # http://patorjk.com/software/taag/#p=display&f=Calvin+S&t=COQUI+GW%2BEDMFT&x=none&v=4&h=4&w=80&we=false
+        print("╔═╗╔═╗╔═╗ ╦ ╦╦  ╔═╗┬ ┬╔═╗┌┬┐┌┬┐┌─┐┌┬┐\n"
+              "║  ║ ║║═╬╗║ ║║  ║ ╦│││║╣  │││││├┤  │ \n"
+              "╚═╝╚═╝╚═╝╚╚═╝╩  ╚═╝└┴┘╚═╝─┴┘┴ ┴└   ┴ \n")
+        print(f"  Total GW+EDMFT cycles (niter)       = {niter}")
+        print(f"  GW iterations per GW+EDMFT cycle    = {gw_iter_per_loop}")
+        print(f"  EDMFT iterations per GW+EDMFT cycle = {edmft_iter_per_loop}")
+        print(f"    - Fix Gloc and Wloc during EDMFT iterations = {inner_loop_alg==2}\n")
 
     # deep copy to avoid any changes in gw_edmft_params affecting outside the function.
     gw_edmft_params = deepcopy(gw_edmft_params)
@@ -90,54 +97,87 @@ def gw_edmft_loop(mf, thc, proj_info, embedding_1e, embedding_2e,
     if impurity_params.pop('restart', False):
         dmft_state.load(solver_chkpt_h5)
 
-    for iteration in range(outer_num_iter):
+
+    for iteration in range(niter):
+
+        if gw_params is not None and gw_iter_per_loop >= 1:
+            # update GW solution with fixed impurity self-energies and polarizabilities
+            _gw_loop(
+                mf, thc, proj_info, 
+                dmft_state, coqui_chkpt_h5, 
+                gw_params, embed_params, gw_iter_per_loop
+            )
+
+        if edmft_iter_per_loop >= 1:
+            # Set the Green's function for the non-local RPA polarizability
+            with HDFArchive(coqui_chkpt_h5, 'r') as ar:
+                mbpt_final_iter = ar["scf/final_iter"]
+                try:
+                    gf_for_wloc_source = ar[f"scf/iter{mbpt_final_iter}/greens_func_source"]
+                    gf_for_wloc_iteration = ar[f"scf/iter{mbpt_final_iter}/greens_func_iteration"]
+                except KeyError:
+                    gf_for_wloc_source = ar[f"scf/iter{mbpt_final_iter}/input_grp"]
+                    gf_for_wloc_iteration = ar[f"scf/iter{mbpt_final_iter}/input_iter"]
+            wloc_params["greens_func_source"] = gf_for_wloc_source
+            wloc_params["greens_func_iteration"] = gf_for_wloc_iteration
+            coqui_mpi.barrier()
+
+            # inner EDMFT loop
+            edmft_alg = {1: _edmft_loop, 2: _edmft_loop_fixed_gloc_and_wloc}
+            try:
+                edmft_impl = edmft_alg[inner_loop_alg]
+            except KeyError:
+                raise ValueError(f"Unknown inner_loop_alg={inner_loop_alg!r} (expected 1, or 2)")
+        
+            edmft_impl(
+                mf, thc, proj_info, dmft_state, solver_chkpt_h5, coqui_chkpt_h5, 
+                gloc_params, wloc_params, impurity_params['solver'], embed_params, 
+                iterative_params, edmft_iter_per_loop
+            )
+
+
+def _gw_loop(mf, thc, proj_info, 
+             dmft_state, coqui_chkpt_h5, 
+             gw_params, embed_params, gw_iter_per_loop):
+    if gw_iter_per_loop < 1:
+        return
+
+    coqui_mpi = mf.mpi()
+    for gw_iteration in range(gw_iter_per_loop):
         with HDFArchive(coqui_chkpt_h5, 'r') as ar:
             greens_func_source = "embed" if "embed" in ar.keys() else "scf"
             greens_func_iteration = ar[f"{greens_func_source}/final_iter"]
         coqui_mpi.barrier()
 
         # GW if gw_params presents
-        if gw_params is not None:
-            gw_params["greens_func_source"] = greens_func_source
-            gw_params["greens_func_iteration"] = greens_func_iteration
-            coqui.run_gw(
-                gw_params, h_int = thc, projector_info = proj_info,
-                local_polarizabilities = dmft_state.local_pi_w
-            )
-        coqui_mpi.barrier()
-
-        # Set the Green's function for the non-local RPA polarizability
-        with HDFArchive(coqui_chkpt_h5, 'r') as ar:
-            mbpt_final_iter = ar["scf/final_iter"]
-            try:
-                gf_for_wloc_source = ar[f"scf/iter{mbpt_final_iter}/greens_func_source"]
-                gf_for_wloc_iteration = ar[f"scf/iter{mbpt_final_iter}/greens_func_iteration"]
-            except KeyError:
-                gf_for_wloc_source = ar[f"scf/iter{mbpt_final_iter}/input_grp"]
-                gf_for_wloc_iteration = ar[f"scf/iter{mbpt_final_iter}/input_iter"]
-        wloc_params["greens_func_source"] = gf_for_wloc_source
-        wloc_params["greens_func_iteration"] = gf_for_wloc_iteration
-        coqui_mpi.barrier()
-
-        # inner EDMFT loop
-        edmft_alg = {1: _edmft_loop, 2: _edmft_loop_fixed_gloc_and_wloc}
-        try:
-            edmft_impl = edmft_alg[inner_loop_alg]
-        except KeyError:
-            raise ValueError(f"Unknown inner_loop_alg={inner_loop_alg!r} (expected 1 or 2)")
-        edmft_impl(
-            mf, thc, proj_info, dmft_state, solver_chkpt_h5,
-            gloc_params, wloc_params, impurity_params['solver'], embed_params,
-            iterative_params, inner_num_iter
+        gw_params["greens_func_source"] = greens_func_source
+        gw_params["greens_func_iteration"] = greens_func_iteration
+        coqui.run_gw(
+            gw_params, h_int = thc, projector_info = proj_info,
+            local_polarizabilities = dmft_state.local_pi_w
         )
+        coqui_mpi.barrier()
+
+        # Don't upfold the results if gw_iter_per_loop==1. 
+        # Not sure if this is the best choice, but it allows us to skip one upfolding in the common case of 
+        # doing just one GW iteration per GW+EDMFT loop, which can save some time.
+        if gw_iter_per_loop > 1: 
+            # Updates GW+EDMFT solution with the latest GW results while keeping the impurity solutions fixed.
+            # Upfolding
+            coqui.dmft_embed(
+                mf, embed_params,
+                projector_info = proj_info,
+                local_hf_potentials = dmft_state.local_sigma_infty,
+                local_sigma_dynamic = dmft_state.local_sigma_w
+            )
+            coqui_mpi.barrier()
 
 
-def _edmft_loop(mf, thc, proj_info, dmft_state, solver_chkpt_h5,
+def _edmft_loop(mf, thc, proj_info, dmft_state, solver_chkpt_h5, coqui_chkpt_h5, 
                gloc_params, wloc_params, solver_params_list, embed_params,
                iterative_params, num_iter):
 
     coqui_mpi = mf.mpi()
-    coqui_chkpt_h5 = gloc_params['outdir']+"/"+gloc_params['prefix']+".mbpt.h5"
 
     for iteration in range(num_iter):
         with HDFArchive(coqui_chkpt_h5, 'r') as ar:
@@ -293,11 +333,10 @@ def _edmft_loop(mf, thc, proj_info, dmft_state, solver_chkpt_h5,
 
 
 def _edmft_loop_fixed_gloc_and_wloc(
-        mf, thc, proj_info, dmft_state, solver_chkpt_h5,
+        mf, thc, proj_info, dmft_state, solver_chkpt_h5, coqui_chkpt_h5, 
         gloc_params, wloc_params, solver_params_list, embed_params,
         iterative_params, num_iter):
     coqui_mpi = mf.mpi()
-    coqui_chkpt_h5 = gloc_params['outdir']+"/"+gloc_params['prefix']+".mbpt.h5"
     with HDFArchive(coqui_chkpt_h5, 'r') as ar:
         greens_func_source = "embed" if "embed" in ar.keys() else "scf"
         greens_func_iteration = ar[f"{greens_func_source}/final_iter"]

--- a/src/python/dmft/scf_driver.py
+++ b/src/python/dmft/scf_driver.py
@@ -27,18 +27,24 @@ import triqs_modest as modest
 import coqui
 from coqui.utils.imag_axes_ft import IAFT
 import coqui.dmft as coqui_dmft
+from coqui.dmft.io import convert_gw_edmft_params, _normalize_solver_params_list
 
 Hartree_eV = 27.211386245988
 
 
-def gw_edmft_loop(mf, thc, proj_info, embedding_1e, 
-                  niter, gw_iter_per_loop=1, edmft_iter_per_loop=1, 
-                  inner_loop_alg=1, **gw_edmft_params):
+def run_gw_edmft(mf, thc, proj_info, embedding_1e, inner_loop_alg=1, **gw_edmft_params):
     """
     GW+EDMFT self-consistency loop
     :return:
     """
     coqui_mpi = mf.mpi()
+
+    # Convert to the internal format
+    gw_edmft_params = convert_gw_edmft_params(gw_edmft_params)
+    niter, gw_iter_per_loop, edmft_iter_per_loop = (
+        gw_edmft_params.pop('niter'), gw_edmft_params.pop('gw_iter_per_loop'), gw_edmft_params.pop('edmft_iter_per_loop')
+    )
+
     if coqui_mpi.root():
         # http://patorjk.com/software/taag/#p=display&f=Calvin+S&t=COQUI+GW%2BEDMFT&x=none&v=4&h=4&w=80&we=false
         print("╔═╗╔═╗╔═╗ ╦ ╦╦  ╔═╗┬ ┬╔═╗┌┬┐┌┬┐┌─┐┌┬┐\n"
@@ -54,8 +60,6 @@ def gw_edmft_loop(mf, thc, proj_info, embedding_1e,
         print(embedding_1e.description(True))
         print(embedding_2e.description(True))
 
-    # deep copy to avoid any changes in gw_edmft_params affecting outside the function.
-    gw_edmft_params = deepcopy(gw_edmft_params)
     try:
         gw_params        = gw_edmft_params.pop('gw', None)
         wloc_params      = gw_edmft_params.pop('wloc')
@@ -64,28 +68,12 @@ def gw_edmft_loop(mf, thc, proj_info, embedding_1e,
         impurity_params  = gw_edmft_params.pop('impurity')
         iterative_params = impurity_params.pop('iter_alg', None)
     except KeyError as e:
-        raise KeyError(f"gw_edmft_loop: Missing required gw_edmft_params key: {e.args[0]}")
+        raise KeyError(f"run_gw_edmft: Missing required gw_edmft_params key: {e.args[0]}")
 
-    if isinstance(impurity_params['solver'], dict):
-        impurity_params['solver'] = [impurity_params['solver']]
-    assert isinstance(impurity_params['solver'], list), (
-        "impurity parameters should be a list of params - one for each impurity"
+    # Scale Monte-Carlo cycle counts by MPI communicator size.
+    impurity_params['solver'] = _normalize_solver_params_list(
+        impurity_params['solver'], coqui_mpi.comm_size()
     )
-    for solver_params in impurity_params['solver']:
-        solver_params['n_cycles'] = int(solver_params['n_cycles']/coqui_mpi.comm_size())
-        mu_params = solver_params.get('chemical_potential')
-        if mu_params and 'n_cycles' in mu_params.keys():
-            mu_params['n_cycles'] = int(mu_params['n_cycles']/coqui_mpi.comm_size())
-
-    if iterative_params is not None:
-        assert iterative_params['alg'] == 'damping', (
-            "Only \'damping\' iterative algorithm is supported in GW+EDMFT at the moment."
-        )
-
-    if gw_params:
-        assert gw_params['screen_type'] == wloc_params['screen_type']
-
-    wloc_params['output_in_tau'] = True
 
     coqui_chkpt_h5 = embed_params['outdir']+"/"+embed_params['prefix']+".mbpt.h5"
     solver_chkpt_h5 = impurity_params.pop('chkpt_h5', coqui_chkpt_h5)
@@ -165,7 +153,7 @@ def _gw_loop(mf, thc, proj_info,
 
         # Don't upfold the results if gw_iter_per_loop==1. 
         # Not sure if this is the best choice, but it allows us to skip one upfolding in the common case of 
-        # doing just one GW iteration per GW+EDMFT loop, which can save some time.
+        # doing just one GW iteration per GW+EDMFT loop, which can save some disk space in the checkpoint h5.
         if gw_iter_per_loop > 1: 
             # Updates GW+EDMFT solution with the latest GW results while keeping the impurity solutions fixed.
             # Upfolding
@@ -277,19 +265,19 @@ def _edmft_loop(mf, thc, proj_info, dmft_state, solver_chkpt_h5, coqui_chkpt_h5,
             )
 
             # Analyze block symmetry
-            if solver_params.get('degenerate_blk'):
-                solver_params['degenerate_blk'] = [np.array(x) for x in solver_params["degenerate_blk"]]
-            elif solver_params.get('degenerate_blk_thresh'):
+            if solver_params.get('degenerate_blk') is None and solver_params.get('degenerate_blk_thresh'):
                 if coqui_mpi.root():
                     print("Analyzing block symmetries via the hybridization function...\n")
+                # Cache the result so subsequent EDMFT iterations skip re-analysis
                 solver_params['degenerate_blk'] = modest.analyze_degenerate_blocks(
                     delta_iw, threshold=solver_params['degenerate_blk_thresh']
                 )
-            if solver_params.get('degenerate_blk'):
-                coqui_dmft.print_degenerate_blks(solver_params['degenerate_blk'], Res['gf_struct'])
-                delta_iw   = modest.symmetrize(delta_iw, solver_params['degenerate_blk'])
-                h0         = coqui_dmft.symmetrize_h0_op(h0, solver_params['degenerate_blk'], Res['gf_struct'])
-                u_weiss_iw = coqui_dmft.symmetrize_blk2_gf(u_weiss_iw, solver_params['degenerate_blk'], Res['gf_struct'])
+            degenerate_blk = solver_params.get('degenerate_blk')
+            if degenerate_blk is not None:
+                coqui_dmft.print_degenerate_blks(degenerate_blk, Res['gf_struct'])
+                delta_iw   = modest.symmetrize(delta_iw, degenerate_blk)
+                h0         = coqui_dmft.symmetrize_h0_op(h0, degenerate_blk, Res['gf_struct'])
+                u_weiss_iw = coqui_dmft.symmetrize_blk2_gf(u_weiss_iw, degenerate_blk, Res['gf_struct'])
 
             # Call impurity solver, and store sigma_imp, vhf_imp, and pi_imp in "Res"
             Res.update(
@@ -433,18 +421,19 @@ def _edmft_loop_fixed_gloc_and_wloc(
             )
 
             # Analyze block symmetry
-            if solver_params.get('degenerate_blk') is None:
+            if solver_params.get('degenerate_blk') is None and solver_params.get('degenerate_blk_thresh'):
                 if coqui_mpi.root():
                     print("Analyzing block symmetries via the hybridization function...\n")
+                # Cache the result so subsequent EDMFT iterations skip re-analysis 
                 solver_params['degenerate_blk'] = modest.analyze_degenerate_blocks(
                     delta_iw, threshold=solver_params['degenerate_blk_thresh']
                 )
-            else:
-                solver_params['degenerate_blk'] = [np.array(x) for x in solver_params["degenerate_blk"]]
-            coqui_dmft.print_degenerate_blks(solver_params['degenerate_blk'], Res['gf_struct'])
-            delta_iw   = modest.symmetrize(delta_iw, solver_params['degenerate_blk'])
-            h0         = coqui_dmft.symmetrize_h0_op(h0, solver_params['degenerate_blk'], Res['gf_struct'])
-            u_weiss_iw = coqui_dmft.symmetrize_blk2_gf(u_weiss_iw, solver_params['degenerate_blk'], Res['gf_struct'])
+            degenerate_blk = solver_params.get('degenerate_blk') 
+            if degenerate_blk is not None:
+                coqui_dmft.print_degenerate_blks(degenerate_blk, Res['gf_struct'])
+                delta_iw   = modest.symmetrize(delta_iw, degenerate_blk)
+                h0         = coqui_dmft.symmetrize_h0_op(h0, degenerate_blk, Res['gf_struct'])
+                u_weiss_iw = coqui_dmft.symmetrize_blk2_gf(u_weiss_iw, degenerate_blk, Res['gf_struct'])
 
             # Call impurity solver, and store sigma_imp, vhf_imp, and pi_imp in "Res"
             Res.update(
@@ -601,13 +590,12 @@ def _solver_inner_loop(coqui_mpi, h0, delta_iw, u_weiss_iw, h_int,
 
 def solve_impurities_from_chkpt(coqui_mpi, dmft_iteration=-1, imp_indices=None, **params):
 
+    params = convert_gw_edmft_params(params)
     imp_params = params.pop('impurity')
-    solver_params_list = imp_params['solver']
-    for solver_params in solver_params_list:
-        solver_params['n_cycles'] = int(solver_params['n_cycles']/coqui_mpi.comm_size())
-        mu_params = solver_params.get('chemical_potential')
-        if mu_params and 'n_cycles' in mu_params.keys():
-            mu_params['n_cycles'] = int(mu_params['n_cycles']/coqui_mpi.comm_size())
+    # Scale Monte-Carlo cycle counts by MPI communicator size.
+    solver_params_list = _normalize_solver_params_list(
+        imp_params['solver'], coqui_mpi.comm_size()
+    )
 
     ir_kernel = IAFT.from_coqui_chkpt(imp_params['chkpt_h5'], verbose=coqui_mpi.root())
     wmax_imp, prec_imp = imp_params.pop('dlr_wmax', ir_kernel.wmax), imp_params.pop('dlr_eps', ir_kernel.prec)
@@ -659,19 +647,18 @@ def solve_impurities_from_chkpt(coqui_mpi, dmft_iteration=-1, imp_indices=None, 
         )
 
         # Analyze block symmetry
-        if solver_params.get('degenerate_blk'):
-            solver_params['degenerate_blk'] = [np.array(x) for x in solver_params["degenerate_blk"]]
-        elif solver_params.get('degenerate_blk_thresh'):
+        if solver_params.get('degenerate_blk') is None and solver_params.get('degenerate_blk_thresh'):
             if coqui_mpi.root():
                 print("Analyzing block symmetries via the hybridization function...\n")
             solver_params['degenerate_blk'] = modest.analyze_degenerate_blocks(
                 delta_iw, threshold=solver_params['degenerate_blk_thresh']
             )
-        if solver_params.get('degenerate_blk'):
-            coqui_dmft.print_degenerate_blks(solver_params['degenerate_blk'], Input['gf_struct'])
-            delta_iw   = modest.symmetrize(delta_iw, solver_params['degenerate_blk'])
-            h0         = coqui_dmft.symmetrize_h0_op(h0, solver_params['degenerate_blk'], Input['gf_struct'])
-            u_weiss_iw = coqui_dmft.symmetrize_blk2_gf(u_weiss_iw, solver_params['degenerate_blk'], Input['gf_struct'])
+        degenerate_blk = solver_params.get('degenerate_blk')
+        if degenerate_blk is not None:
+            coqui_dmft.print_degenerate_blks(degenerate_blk, Input['gf_struct'])
+            delta_iw   = modest.symmetrize(delta_iw, degenerate_blk)
+            h0         = coqui_dmft.symmetrize_h0_op(h0, degenerate_blk, Input['gf_struct'])
+            u_weiss_iw = coqui_dmft.symmetrize_blk2_gf(u_weiss_iw, degenerate_blk, Input['gf_struct'])
 
         # Call impurity solver, and store sigma_imp, vhf_imp, and pi_imp in "Res"
         Res = _solver_inner_loop(coqui_mpi, h0, delta_iw, u_weiss_iw, h_int, Input['density'], **solver_params)

--- a/src/python/dmft/scf_driver.py
+++ b/src/python/dmft/scf_driver.py
@@ -271,7 +271,8 @@ def _edmft_loop(mf, thc, proj_info, dmft_state, solver_chkpt_h5,
 
             # mixing impurity and dc solutions to facilitate convergence
             dmft_state.damp_impurity_results(
-                solver_chkpt_h5, mixing=iterative_params.get('mixing', 0.7), impurity_indices=[imp_index]
+                solver_chkpt_h5, mixing=iterative_params.get('mixing', 0.7), impurity_indices=[imp_index], 
+                mix_in_first_iter=iterative_params.get('mix_in_first_iter', False)
             )
 
             # save solver results for current impurity
@@ -425,7 +426,8 @@ def _edmft_loop_fixed_gloc_and_wloc(
 
             # mixing impurity and dc solutions to facilitate convergence
             dmft_state.damp_impurity_results(
-                solver_chkpt_h5, mixing = iterative_params.get('mixing', 0.7), impurity_indices=[imp_index]
+                solver_chkpt_h5, mixing = iterative_params.get('mixing', 0.7), impurity_indices=[imp_index], 
+                mix_in_first_iter=iterative_params.get('mix_in_first_iter', False)
             )
 
             # save solver results for current impurity
@@ -493,7 +495,7 @@ def _compute_weiss_fields(coqui_mpi, imp_results, imp_inputs, solver_params, ir_
                     "Wloc_t": imp_inputs['Wloc_t'],
                     "Vloc": imp_inputs['Vloc']
                 },
-                init_weiss_type = solver_params.get('init_weiss_type', 'dc'),
+                init_imp_results = solver_params.get('init_imp_results', 'dc'),
                 density_only=True
             )
         )
@@ -504,7 +506,7 @@ def _solver_inner_loop(coqui_mpi, h0, delta_iw, u_weiss_iw, h_int,
 
     solver_params.pop('degenerate_blk_thresh', None)
     solver_params.pop('set_sigma_infty_to_dc', None)
-    solver_params.pop('init_weiss_type', None)
+    solver_params.pop('init_imp_results', None)
     solver_params.pop("causal_projection", None)
     solver_params.pop("screen_j", None)
     mu_params = solver_params.pop('chemical_potential', None)

--- a/src/python/dmft/scf_driver.py
+++ b/src/python/dmft/scf_driver.py
@@ -561,6 +561,9 @@ def solve_impurities_from_chkpt(coqui_mpi, dmft_iteration=-1, imp_indices=None, 
     solver_params_list = imp_params['solver']
     for solver_params in solver_params_list:
         solver_params['n_cycles'] = int(solver_params['n_cycles']/coqui_mpi.comm_size())
+        mu_params = solver_params.get('chemical_potential')
+        if mu_params and 'n_cycles' in mu_params.keys():
+            mu_params['n_cycles'] = int(mu_params['n_cycles']/coqui_mpi.comm_size())
 
     ir_kernel = IAFT.from_coqui_chkpt(imp_params['chkpt_h5'], verbose=coqui_mpi.root())
     wmax_imp, prec_imp = imp_params.pop('dlr_wmax', ir_kernel.wmax), imp_params.pop('dlr_eps', ir_kernel.prec)

--- a/src/python/dmft/weiss.py
+++ b/src/python/dmft/weiss.py
@@ -271,18 +271,18 @@ def extract_h0_and_delta(g_weiss_wsab, ir_kernel, high_freq_multiplier=10):
 
     return t_sIab_estimate, delta_estimate
 
-
-def init_weiss_fields_w(*, ir_kernel, local_gf, init_weiss_type="dc", density_only=False):
+# TODO merge call compute_weiss_fields_w internally to avoid code duplication
+def init_weiss_fields_w(*, ir_kernel, local_gf, init_imp_results="dc", density_only=False):
     # checking inputs
     missing = {"Gloc_t", "Wloc_t", "Vloc"} - local_gf.keys()
     if missing:
         raise ValueError(f"Missing keys in local_gf: {missing}")
 
-    if init_weiss_type not in {"dc", "zero"}:
-        raise ValueError(f"init_weiss_type must be 'dc' or 'zero', got {init_weiss_type}")
+    if init_imp_results not in {"dc", "zero"}:
+        raise ValueError(f"init_imp_results must be 'dc' or 'zero', got {init_imp_results}")
 
     # bosonic first
-    if init_weiss_type == "dc":
+    if init_imp_results == "dc":
         mpi.report("Evaluate the bosonic Weiss field at the RPA level.")
         pi_imp_w = ir_kernel.tau_to_w_phsym(eval_pi_rpa(local_gf["Gloc_t"], density_only=density_only), stats='b')
         if len(pi_imp_w.shape) == 3:
@@ -302,7 +302,7 @@ def init_weiss_fields_w(*, ir_kernel, local_gf, init_weiss_type="dc", density_on
     mpi.barrier()
 
     # fermionic
-    if init_weiss_type == "dc":
+    if init_imp_results == "dc":
         mpi.report("Evaluate the fermionic Weiss field using the local GW self-energy.")
         vhf_imp = eval_hf_dc(
             -ir_kernel.tau_interpolate(local_gf["Gloc_t"], [ir_kernel.beta], stats='f')[0],
@@ -407,8 +407,10 @@ def compute_weiss_boson_w(V_abcd, W_wabcd, Pi_wabcd):
     U_pb = np.zeros(Wfull_pb.shape, dtype=Wfull_pb.dtype)
     for n, W in enumerate(Wfull_pb):
         X = np.eye(nbnd2) + Pi_pb[n] @ W
-        X_inv = np.linalg.solve(X, np.eye(nbnd2))
-        U_pb[n] = W @ X_inv
+        cond = np.linalg.cond(X)
+        if cond > 20: 
+            mpi.report(f"WARNING: Large condition number for [I + Pi(w)*W(w)] = {cond} at n = {n}.")    
+        U_pb[n] = W @ np.linalg.pinv(X)
 
     return U_pb.reshape(W_wabcd.shape) - V_abcd
 

--- a/src/wannier/tests/test_wannier.cpp
+++ b/src/wannier/tests/test_wannier.cpp
@@ -127,10 +127,10 @@ namespace wannier_tests {
       ARRAY_EQUAL(proj_mat_out, proj_mat_ref, 1e-6, 1e-8);
 
       // Hopping/eigenvalue comparison (should be very close)
-      ARRAY_EQUAL(hopping_out, hopping_ref, 1e-10, 1e-10);
+      ARRAY_EQUAL(hopping_out, hopping_ref, 1e-6, 1e-8);
 
       // Wannier centres comparison
-      ARRAY_EQUAL(wan_centres_out, wan_centres_ref, 1e-10, 1e-10);
+      ARRAY_EQUAL(wan_centres_out, wan_centres_ref, 1e-6, 1e-8);
 
       app_log(0, "wannier_tests: Successfully compared generated {}.mlwf.h5 with reference", prefix);
       mpi->comm.barrier();


### PR DESCRIPTION
This PR refactors the GW+EDMFT workflow, improves divergence treatment. 

### Divergence treatment
- Refactor `g0_div_utils.hpp`. 
- remove `div_treament_e` enum, and use std::string instead for flexibility. 
- Updated the default divergence treatment (`gygi`) to perform a polynomial extrapolation of $\epsilon^{-1}(q\rightarrow0,i\omega)$ as an $O(q^2)$ with arbitrary order, using the closest q-points along each signed reciprocal direction independently (`+b1/-b1`, `+b2/-b2`, `+b3/-b3`), instead of simply taking the single nearest q-point. The fit order is controlled via `order_N` suffice (e.g. `gygi_order_3`). 
- Added metallic variants (`gygi_metal`, `gygi_metal_order_3`) enforcing the static inverse-dielectric head behavior at $\omega=0$.

### GW+EDMFT loop/API
- Renamed `gw_edmft_loop` to `run_gw_edmft`.
- Renamed `init_weiss_type` to `init_imp_results`.
- Added `mix_in_first_iter` to control first-iteration mixing behavior.
- Flexible controls on how many GW/EDFMT updates per GW+EDMFT cycle via `gw_iter_per_loop` and `edmft_iter_per_loop`.  
- Updated GW+EDMFT examples and parameter files accordingly.
- Generalized impurity $\omega=0$ regularization using $O(\omega^2)$ polynomial extrapolation of arbitrary order. The fit order is controlled via `order_N` suffice (e.g. `extrapolate_order_2`)

### Testing
- Relaxed overly tight MLWF unit-test tolerance