### PR TITLE
add new functions to imaginary axis fourier transform

### DIFF
--- a/src/numerics/imag_axes_ft/IAFT.hpp
+++ b/src/numerics/imag_axes_ft/IAFT.hpp
@@ -129,6 +129,9 @@ namespace imag_axes_ft {
     template<nda::MemoryArray ndaArray_A, nda::MemoryArray ndaArray_B>
     void tau_to_w(ndaArray_A &&X_ti, ndaArray_B &&X_wi, stats_e stats) const;
 
+    template<nda::MemoryArray ndaArray_A_t, nda::MemoryArray ndaArray_B_t>
+    void tau_to_w(ndaArray_A_t &&X_wi, stats_e stats_A, ndaArray_B_t &&X_ti, stats_e stats_B) const;
+ 
     template<nda::MemoryArray ndaArray_A, nda::MemoryArray ndaArray_B>
     void tau_to_w(ndaArray_A &&X_ti, ndaArray_B &&Xw_i, stats_e stats, size_t iw) const;
  
@@ -188,6 +191,15 @@ namespace imag_axes_ft {
      */
     template<nda::MemoryArray ndaArray_A, nda::MemoryArray ndaArray_B>
     void tau_to_beta(ndaArray_A &&A_ti, ndaArray_B &&A_beta_i) const;
+ 
+    /**
+     * Interpolation from bosonic sparse sampling nodes to tau = beta^{-} with particle-hole symmetry.
+     * This function is useful for Matsubara frequency summation: 1/beta \sum_{n} A(iwn) = -1.0 * A(tau=beta^{-})
+     * @param A_ti_pos - [INPUT] imaginary-time tensor on bosonic tau grid
+     * @param A_beta_i - [OUTPUT] imaginary-time tensor at tau = beta^{-}
+     */
+    template<nda::MemoryArray ndaArray_A, nda::MemoryArray ndaArray_B>
+    void tau_to_beta_PHsym(ndaArray_A &&A_ti_pos, ndaArray_B &&A_beta_i) const;
  
     /**
      * Interpolation from fermionic sparse sampling nodes to tau = 0^{+}.

--- a/src/numerics/imag_axes_ft/IAFT.hpp
+++ b/src/numerics/imag_axes_ft/IAFT.hpp
@@ -9,7 +9,7 @@
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -86,15 +86,18 @@ namespace imag_axes_ft {
     template<nda::MemoryArray ndaArray_A, nda::MemoryArray ndaArray_B>
     void tau_to_w(ndaArray_A &&X_ti, ndaArray_B &&X_wi, stats_e stats) const;
 
+    template<nda::MemoryArray ndaArray_A_t, nda::MemoryArray ndaArray_B_t>
+    void tau_to_w(ndaArray_A_t &&X_wi, stats_e stats_A, ndaArray_B_t &&X_ti, stats_e stats_B) const;
+
     template<nda::MemoryArray ndaArray_A, nda::MemoryArray ndaArray_B>
     void tau_to_w(ndaArray_A &&X_ti, ndaArray_B &&Xw_i, stats_e stats, size_t iw) const;
- 
+
     /**
      * version for FT with particle-hole symmetry
      */
     template<nda::MemoryArray Array_tau_t, nda::MemoryArray Array_w_t>
     void tau_to_w_PHsym(Array_tau_t &&X_ti_pos, Array_w_t &&X_wi_pos) const;
- 
+
     /**
      * Transformation from Matsubara frequencies to imaginary times
      * @param X_wi  - [INPUT] Matsubara frequency tensor
@@ -103,16 +106,16 @@ namespace imag_axes_ft {
      */
     template<nda::MemoryArray ndaArray_A, nda::MemoryArray ndaArray_B>
     void w_to_tau(ndaArray_A &&X_wi, ndaArray_B &&X_ti, stats_e stats) const;
- 
+
     /**
      * version for FT with particle-hole symmetry
      */
     template<nda::MemoryArray Array_w_t, nda::MemoryArray Array_tau_t>
     void w_to_tau_PHsym(Array_w_t &&X_wi_pos, Array_tau_t &&X_ti_pos) const;
- 
+
     template<nda::MemoryArray ndaArray_A_t, nda::MemoryArray ndaArray_B_t>
     void w_to_tau(ndaArray_A_t &&X_wi, stats_e stats_A, ndaArray_B_t &&X_ti, stats_e stats_B) const;
- 
+
     /**
      * Partial transformation from Matsubara frequencies to imaginary times
      * X(t, ...) = sum_{n} Ttw(t, wn) * X(wn, ...) = sum_{n} X(t, ..., n)
@@ -124,7 +127,7 @@ namespace imag_axes_ft {
      */
     template<nda::MemoryArray ndaArray_A, nda::MemoryArray ndaArray_B>
     void w_to_tau_partial(ndaArray_A&& Xw_i, ndaArray_B&& X_ti, stats_e stats, size_t iwn) const;
- 
+
     /**
      * Interpolation from tau_A grid to tau_B grid with different statistics
      * @param A_ti     - [INPUT] imaginary-time tensor on tau_A grid
@@ -133,10 +136,10 @@ namespace imag_axes_ft {
      */
     template<nda::MemoryArray ndaArray_A, nda::MemoryArray ndaArray_B>
     void tau_to_tau(ndaArray_A &&A_ti, stats_e A_stats, ndaArray_B &&B_ti) const;
- 
+
     template<nda::MemoryArray ndaArray_A, nda::MemoryArray ndaArray_B>
     void tau_to_tau(ndaArray_A &&A_ti, stats_e A_stats, ndaArray_B &&Bt_i, size_t it_B) const;
- 
+
     /**
      * Interpolation from fermionic sparse sampling nodes to tau = beta^{-}.
      * This function is useful for Matsubara frequency summation: 1/beta \sum_{n} A(iwn) = -1.0 * A(tau=beta^{-})
@@ -145,7 +148,16 @@ namespace imag_axes_ft {
      */
     template<nda::MemoryArray ndaArray_A, nda::MemoryArray ndaArray_B>
     void tau_to_beta(ndaArray_A &&A_ti, ndaArray_B &&A_beta_i) const;
- 
+
+    /**
+     * Interpolation from bosonic sparse sampling nodes to tau = beta^{-} with particle-hole symmetry.
+     * This function is useful for Matsubara frequency summation: 1/beta \sum_{n} A(iwn) = -1.0 * A(tau=beta^{-})
+     * @param A_ti_pos - [INPUT] imaginary-time tensor on bosonic tau grid
+     * @param A_beta_i - [OUTPUT] imaginary-time tensor at tau = beta^{-}
+     */
+    template<nda::MemoryArray ndaArray_A, nda::MemoryArray ndaArray_B>
+    void tau_to_beta_PHsym(ndaArray_A &&A_ti_pos, ndaArray_B &&A_beta_i) const;
+
     /**
      * Interpolation from fermionic sparse sampling nodes to tau = 0^{+}.
      * This function is needed to evaluate overlap matrix inverse as S = -(G(0^{+}) + G(\beta^{-}))
@@ -153,17 +165,17 @@ namespace imag_axes_ft {
      * @param A_zero_i - [OUTPUT] imaginary-time tensor at tau = zero^{+}
      */
     template<nda::MemoryArray ndaArray_A, nda::MemoryArray ndaArray_B>
-    void tau_to_zero(ndaArray_A &&A_ti, ndaArray_B &&A_zero_i)  const;
- 
+    void tau_to_zero(ndaArray_A &&A_ti, ndaArray_B &&A_zero_i) const;
+
     template<nda::MemoryArray Array_A, typename comm_t>
     void check_leakage(Array_A &&A_ti, stats_e stats, comm_t *comm, std::string A_name) const;
- 
+
     template<nda::MemoryArray Array_A, typename comm_t>
     void check_leakage_PHsym(Array_A &&A_ti, stats_e stats, comm_t *comm, std::string A_name) const;
- 
+
     template<typename A_t>
     void check_leakage(A_t &&A_ti, stats_e stats, std::string A_name, bool PHsym=false) const;
- 
+
   private:
     std::variant<ir::IR> grid_var;
 
@@ -248,7 +260,7 @@ namespace imag_axes_ft {
   };
 
   // include definition of template member functions
-  #include"numerics/imag_axes_ft/IAFT.icc" 
+  #include"numerics/imag_axes_ft/IAFT.icc"
 } // imag_axes_ft
 
 

--- a/src/numerics/imag_axes_ft/IAFT.hpp
+++ b/src/numerics/imag_axes_ft/IAFT.hpp
@@ -327,7 +327,7 @@ namespace imag_axes_ft {
       return std::visit( [&](auto&& v) { return v.nt_f; }, grid_var);
     }
     int nt_b() const {
-      return std::visit( [&](auto&& v) { return v.nt_f; }, grid_var);
+      return std::visit( [&](auto&& v) { return v.nt_b; }, grid_var);
     }
     int nw_f() const {
       return std::visit( [&](auto&& v) { return v.nw_f; }, grid_var);

--- a/src/numerics/imag_axes_ft/IAFT.icc
+++ b/src/numerics/imag_axes_ft/IAFT.icc
@@ -25,6 +25,31 @@ void IAFT::tau_to_w(ndaArray_A &&X_ti, ndaArray_B &&X_wi, stats_e stats) const {
   }
 }
 
+template<nda::MemoryArray ndaArray_A_t, nda::MemoryArray ndaArray_B_t>
+void IAFT::tau_to_w(ndaArray_A_t &&X_ti, stats_e stats_A, ndaArray_B_t &&X_wi, stats_e stats_B) const {
+  if (stats_A == stats_B) {
+    tau_to_w(X_ti, X_wi, stats_A);
+  } else {
+    static_assert(nda::get_rank<ndaArray_A_t> == nda::get_rank<ndaArray_B_t>,
+                  "iaft::tau_to_tau: incorrect rank of array X_wi and X_ti. ");
+
+    size_t nt = (stats_A == fermi)? nt_f() : nt_b();
+    size_t nw = (stats_B == fermi)? nw_f() : nw_b();
+    utils::check(X_ti.shape(0) == nt, "iaft::tau_to_w: incorrect dimension of nw for X_t; stats = {}", int(stats_A));
+    utils::check(X_wi.shape(0) == nw, "iaft::tau_to_w: incorrect dimension of nt for X_w; stats = {}", int(stats_B));
+
+    long dim1 = std::accumulate(X_ti.shape().begin()+1, X_ti.shape().end(), 1, std::multiplies<>{});
+    auto X_ti_2D = nda::reshape(X_ti, shape_t<2>{nt, dim1});
+    auto X_wi_2D = nda::reshape(X_wi, shape_t<2>{nw, dim1});
+
+    // t -> t other -> w
+    nda::matrix<ComplexType> TT(nw, nt);
+    TT = (stats_A == fermi)? Twt_bb() * Ttt_bf() : Twt_ff() * Ttt_fb();
+    nda::blas::gemm(TT, X_ti_2D, X_wi_2D);
+  }
+}
+
+
 template<nda::MemoryArray ndaArray_A, nda::MemoryArray ndaArray_B>
 void IAFT::tau_to_w(ndaArray_A &&X_ti, ndaArray_B &&Xw_i, stats_e stats, size_t iw) const {
   static_assert(nda::get_rank<ndaArray_A>-1 == nda::get_rank<ndaArray_B>,
@@ -163,7 +188,7 @@ void IAFT::w_to_tau(ndaArray_A_t &&X_wi, stats_e stats_A, ndaArray_B_t &&X_ti, s
 template<nda::MemoryArray ndaArray_A, nda::MemoryArray ndaArray_B>
 void IAFT::w_to_tau_partial(ndaArray_A&& Xw_i, ndaArray_B&& X_ti, stats_e stats, size_t iwn) const {
   static_assert(nda::get_rank<ndaArray_A> == nda::get_rank<ndaArray_B>-1,
-      "iaft::w_to_tau_partial: incorrect rank of array Xw_i and X_ti. ");
+                "iaft::w_to_tau_partial: incorrect rank of array Xw_i and X_ti. ");
   size_t nt = (stats == fermi)? nt_f() : nt_b();
   const long dim1 = std::accumulate(X_ti.shape().begin()+1, X_ti.shape().end(), 1, std::multiplies<>{});
   utils::check(X_ti.shape(0) == nt, "iaft::w_to_tau_partial: incorrect dimension of nt for X_t; stats = {}", int(stats));
@@ -238,13 +263,44 @@ void IAFT::tau_to_beta(ndaArray_A &&A_ti, ndaArray_B &&A_beta_i) const {
 }
 
 /**
+ * Interpolation from bosonic sparse sampling nodes to tau = beta^{-} with particle-hole symmetry.
+ * This function is useful for Matsubara frequency summation: 1/beta \sum_{n} A(iwn) = -1.0 * A(tau=beta^{-})
+ * @param A_ti_pos - [INPUT] imaginary-time tensor on bosonic tau grid
+ * @param A_beta_i - [OUTPUT] imaginary-time tensor at tau = beta^{-}
+ */
+template<nda::MemoryArray ndaArray_A, nda::MemoryArray ndaArray_B>
+void IAFT::tau_to_beta_PHsym(ndaArray_A &&A_ti_pos, ndaArray_B &&A_beta_i) const {
+  static_assert(nda::get_rank<ndaArray_A>-1 == nda::get_rank<ndaArray_B>,
+                "iaft::tau_to_beta_PHsym: incorrect rank of array A_ti_pos and A_beta_i. ");
+
+  size_t nt_half = (nt_b()%2==0)? nt_b()/2 : nt_b()/2 + 1;
+  utils::check(A_ti_pos.shape(0) == nt_half, "iaft::tau_to_beta_PHsym: incorrect dimension of nt_half for A_ti_pos.");
+  long dim1 = std::accumulate(A_ti_pos.shape().begin()+1, A_ti_pos.shape().end(), 1, std::multiplies<>{});
+  utils::check(A_beta_i.size() == dim1, "iaft::tau_to_beta_PHsym: incorrect dimension for A_beta_i");
+
+  auto A_beta_i_1D = nda::reshape(A_beta_i, shape_t<1>{dim1});
+  nda::matrix_const_view<ComplexType> A_ti_pos_2D({nt_half, dim1}, A_ti_pos.data());
+  auto A_it_pos_2D = nda::transpose(A_ti_pos_2D);
+
+  nda::array<ComplexType, 1> T_beta_tau(nt_b());
+  nda::blas::gemv(nda::transpose(Ttt_fb()), T_beta_t_ff(), T_beta_tau);
+  nda::array<ComplexType, 1> T_beta_tau_pos(nt_half);
+  for (long it = 0; it < nt_half; ++it) {
+      long imt = nt_b() - it - 1;
+      T_beta_tau_pos(it) = (it == imt)? T_beta_tau(it) : T_beta_tau(it) + T_beta_tau(imt);
+  }
+  // (w,i) = (w,t) * (t,i)
+  nda::blas::gemv(A_it_pos_2D, T_beta_tau_pos, A_beta_i_1D);
+}
+
+/**
  * Interpolation from fermionic sparse sampling nodes to tau = 0^{+}.
  * This function is needed to evaluate overlap matrix inverse as S = -(G(0^{+}) + G(\beta^{-}))
  * @param A_ti     - [INPUT] imaginary-time tensor on fermionic tau grid
  * @param A_zero_i - [OUTPUT] imaginary-time tensor at tau = zero^{+}
  */
 template<nda::MemoryArray ndaArray_A, nda::MemoryArray ndaArray_B>
-void IAFT::tau_to_zero(ndaArray_A &&A_ti, ndaArray_B &&A_zero_i)  const {
+void IAFT::tau_to_zero(ndaArray_A &&A_ti, ndaArray_B &&A_zero_i) const {
   static_assert(nda::get_rank<ndaArray_A>-1 == nda::get_rank<ndaArray_B>,
                 "iaft::tau_to_zero: incorrect rank of array A_ti and A_beta_i. ");
   utils::check(A_ti.shape(0) == nt_f(), "iaft::tau_to_zero: incorrect dimension of nt for A_ti.");

--- a/src/numerics/imag_axes_ft/IAFT.icc
+++ b/src/numerics/imag_axes_ft/IAFT.icc
@@ -25,6 +25,31 @@ void IAFT::tau_to_w(ndaArray_A &&X_ti, ndaArray_B &&X_wi, stats_e stats) const {
   }
 }
 
+template<nda::MemoryArray ndaArray_A_t, nda::MemoryArray ndaArray_B_t>
+void IAFT::tau_to_w(ndaArray_A_t &&X_ti, stats_e stats_A, ndaArray_B_t &&X_wi, stats_e stats_B) const {
+  if (stats_A == stats_B) {
+    tau_to_w(X_ti, X_wi, stats_A);
+  } else {
+    static_assert(nda::get_rank<ndaArray_A_t> == nda::get_rank<ndaArray_B_t>,
+                  "iaft::tau_to_w: incorrect rank of array X_wi and X_ti. ");
+
+    size_t nt = (stats_A == fermion)? nt_f() : nt_b();
+    size_t nw = (stats_B == fermion)? nw_f() : nw_b();
+    utils::check(X_ti.shape(0) == nt, "iaft::tau_to_w: incorrect dimension of nw for X_t; stats = {}", int(stats_A));
+    utils::check(X_wi.shape(0) == nw, "iaft::tau_to_w: incorrect dimension of nt for X_w; stats = {}", int(stats_B));
+
+    long dim1 = std::accumulate(X_ti.shape().begin()+1, X_ti.shape().end(), 1, std::multiplies<>{});
+    auto X_ti_2D = nda::reshape(X_ti, shape_t<2>{nt, dim1});
+    auto X_wi_2D = nda::reshape(X_wi, shape_t<2>{nw, dim1});
+
+    // t -> t other -> w
+    nda::matrix<ComplexType> TT(nw, nt);
+    TT = (stats_A == fermion)? Twt_bb() * Ttt_bf() : Twt_ff() * Ttt_fb();
+    nda::blas::gemm(TT, X_ti_2D, X_wi_2D);
+  }
+}
+
+
 template<nda::MemoryArray ndaArray_A, nda::MemoryArray ndaArray_B>
 void IAFT::tau_to_w(ndaArray_A &&X_ti, ndaArray_B &&Xw_i, stats_e stats, size_t iw) const {
   static_assert(nda::get_rank<ndaArray_A>-1 == nda::get_rank<ndaArray_B>,
@@ -235,6 +260,37 @@ void IAFT::tau_to_beta(ndaArray_A &&A_ti, ndaArray_B &&A_beta_i) const {
   auto A_it_2D = nda::transpose(A_ti_2D);
   //(dim1) = (dim1,nt_f) * (nt_f)
   nda::blas::gemv(A_it_2D, T_beta_t_ff(), A_beta_i_1D);
+}
+
+/**
+ * Interpolation from bosonic sparse sampling nodes to tau = beta^{-} with particle-hole symmetry.
+ * This function is useful for Matsubara frequency summation: 1/beta \sum_{n} A(iwn) = -1.0 * A(tau=beta^{-})
+ * @param A_ti_pos - [INPUT] imaginary-time tensor on bosonic tau grid
+ * @param A_beta_i - [OUTPUT] imaginary-time tensor at tau = beta^{-}
+ */
+template<nda::MemoryArray ndaArray_A, nda::MemoryArray ndaArray_B>
+void IAFT::tau_to_beta_PHsym(ndaArray_A &&A_ti_pos, ndaArray_B &&A_beta_i) const {
+  static_assert(nda::get_rank<ndaArray_A>-1 == nda::get_rank<ndaArray_B>,
+                "iaft::tau_to_beta_PHsym: incorrect rank of array A_ti_pos and A_beta_i. ");
+
+  size_t nt_half = (nt_b()%2==0)? nt_b()/2 : nt_b()/2 + 1;
+  utils::check(A_ti_pos.shape(0) == nt_half, "iaft::tau_to_beta_PHsym: incorrect dimension of nt_half for A_ti_pos.");
+  long dim1 = std::accumulate(A_ti_pos.shape().begin()+1, A_ti_pos.shape().end(), 1, std::multiplies<>{});
+  utils::check(A_beta_i.size() == dim1, "iaft::tau_to_beta_PHsym: incorrect dimension for A_beta_i");
+
+  auto A_beta_i_1D = nda::reshape(A_beta_i, shape_t<1>{dim1});
+  nda::matrix_const_view<ComplexType> A_ti_pos_2D({nt_half, dim1}, A_ti_pos.data());
+  auto A_it_pos_2D = nda::transpose(A_ti_pos_2D);
+
+  nda::array<ComplexType, 1> T_beta_tau(nt_b());
+  nda::blas::gemv(nda::transpose(Ttt_fb()), T_beta_t_ff(), T_beta_tau);
+  nda::array<ComplexType, 1> T_beta_tau_pos(nt_half);
+  for (long it = 0; it < nt_half; ++it) {
+      long imt = nt_b() - it - 1;
+      T_beta_tau_pos(it) = (it == imt)? T_beta_tau(it) : T_beta_tau(it) + T_beta_tau(imt);
+  }
+  // (w,i) = (w,t) * (t,i)
+  nda::blas::gemv(A_it_pos_2D, T_beta_tau_pos, A_beta_i_1D);
 }
 
 /**


### PR DESCRIPTION
This pull request provides two new functions for Fourier transform on the imaginary axes:

1. Fourier transform from imaginary time domain to imaginary frequency domain, even if the grids have different statistics

2. Extrapolation from imaginary time sampling with particle-hole symmetry to $\tau=\beta^{-}$ 