### PR TITLE
Refactor QP-SCF routines

### DIFF
--- a/examples/python_interface/mbpt/02a_gw.py
+++ b/examples/python_interface/mbpt/02a_gw.py
@@ -16,8 +16,8 @@ svo_mf = coqui.make_mf(mpi, params=mf_params, mf_type="qe")
 
 # construct thc handler and compute the thc integrals during initialization
 eri_params = {
-    "ecut": svo_mf.ecutwfc()*1.2,
-    "thresh": 1e-3,
+    "ecut": svo_mf.ecutrho()*0.4,
+    "thresh": 1e-5,
 }
 svo_thc = coqui.make_thc_coulomb(mf=svo_mf, params=eri_params)
 
@@ -25,11 +25,10 @@ svo_thc = coqui.make_thc_coulomb(mf=svo_mf, params=eri_params)
 gw_params = {
     "beta": 200,
     "iaft": {
-        "wmax": 3.0,
         "prec": "medium"
     },
     "niter": 4,
-    "output": "svo_gw",
+    "output": "svo.gw",
     "iter_alg": {
         "alg": "damping",
         "mixing": 0.7

--- a/examples/python_interface/mbpt/02b_evgw.py
+++ b/examples/python_interface/mbpt/02b_evgw.py
@@ -24,31 +24,28 @@ svo_mf = coqui.make_mf(mpi, params=mf_params, mf_type="qe")
 
 # construct thc handler and compute the thc integrals during initialization
 eri_params = {
-    "ecut": svo_mf.ecutwfc()*1.2,
-    "thresh": 1e-3,
+    "ecut": svo_mf.ecutrho()*0.4,
+    "thresh": 1e-5,
 }
 svo_thc = coqui.make_thc_coulomb(mf=svo_mf, params=eri_params)
 
 # GW
 gw_params = {
-    "output": "qpg0w0",
+    "output": "svo.evgw",
     "niter": 1,
     "beta": 200,
     "iaft": {
-        "wmax": 3.0,
         "prec": "medium"
     },
-    "qp_type": "sc",
-    "ac_alg": "pade",
-    "eta": 1e-6,
-    "Nfit": 26
+    "Nfit": -1, 
+    "keep_scr_coulomb_fixed": False # True for evgw0, False for evgw
 }
-coqui.run_qpg0w0(params=gw_params, h_int=svo_thc)
+coqui.run_evgw(params=gw_params, h_int=svo_thc)
 
 # Wannier interpolation for G0W0
 winter_params = {
     "outdir": "./",
-    "prefix": "qpg0w0",
+    "prefix": "svo.evgw",
     "iteration": 1,
     "wannier_file": wan_h5, 
     "bands_num_npoints": 100, 
@@ -71,15 +68,14 @@ mpi.barrier()
 # Plotting
 if mpi.root():
   fig, ax = plt.subplots(1, figsize=(7,5.5), dpi=80)
-  plot_utils.band_plot(ax, "qpg0w0.mbpt.h5", iteration=0, color='tab:blue', linestyle="--",  
+  plot_utils.band_plot(ax, "svo.evgw.mbpt.h5", iteration=0, color='tab:blue', linestyle="--",  
                        linewidth=2.0, label='PBE', fontsize=16)
-  plot_utils.band_plot(ax, "qpg0w0.mbpt.h5", iteration=1, color='tab:red', linestyle="-", 
-                       linewidth=2.0, label='G0W0@PBE', fontsize=16)
+  plot_utils.band_plot(ax, "svo.evgw.mbpt.h5", iteration=1, color='tab:red', linestyle="-", 
+                       linewidth=2.0, label='evGW', fontsize=16)
   ax.axhline(y=0, color = 'black', linestyle = '-', linewidth=2.0, alpha=0.5)
-  #ax.set_ylim(-10.884, 10.884)
   ax.legend(loc=1, fontsize=16)
   plt.tight_layout()
   
-  plt.savefig("qpg0w0.png", format="png")
+  plt.savefig("svo.evgw.png", format="png")
 
 mpi.barrier()

--- a/examples/python_interface/mbpt/02c_qpgw.py
+++ b/examples/python_interface/mbpt/02c_qpgw.py
@@ -1,0 +1,82 @@
+from mpi4py import MPI
+
+import matplotlib.pyplot as plt
+plt.style.use("seaborn-v0_8-deep")
+
+import coqui
+from coqui.post_proc import band_interpolation
+import coqui.post_proc.plot_utils as plot_utils
+
+qe_dir = coqui.TEST_INPUT_DIR + "qe/svo_kp222_nbnd40/out"
+wan_h5 = coqui.TEST_INPUT_DIR + "qe/svo_kp222_nbnd40/mlwf/svo.mlwf.h5"
+
+# mpi handler and verbosity
+mpi = coqui.MpiHandler()
+coqui.set_verbosity(mpi, output_level=1)
+
+# construct MF from a dictionary 
+mf_params = {
+    "prefix": "svo",
+    "outdir": qe_dir,
+    "nbnd": 40
+}
+svo_mf = coqui.make_mf(mpi, params=mf_params, mf_type="qe")
+
+# construct thc handler and compute the thc integrals during initialization
+eri_params = {
+    "ecut": svo_mf.ecutrho()*0.4,
+    "thresh": 1e-5,
+}
+svo_thc = coqui.make_thc_coulomb(mf=svo_mf, params=eri_params)
+
+# GW
+gw_params = {
+    "output": "svo.qpgw",
+    "niter": 1,
+    "beta": 200,
+    "iaft": {
+        "prec": "medium"
+    },
+    "Nfit": -1, 
+    "off_diag_mode": "fermi" # "fermi" or "qp_energy"
+}
+coqui.run_qpgw(params=gw_params, h_int=svo_thc)
+
+# Wannier interpolation for G0W0
+winter_params = {
+    "outdir": "./",
+    "prefix": "svo.qpgw",
+    "iteration": 1,
+    "wannier_file": wan_h5, 
+    "bands_num_npoints": 100, 
+    "kpath": """
+      G 0.00 0.00 0.00
+      X 0.00 0.50 0.00
+      M 0.50 0.50 0.00
+      G 0.00 0.00 0.00
+    """
+}
+
+band_interpolation(svo_mf, winter_params)
+
+# Wannier interpolation for PBE 
+winter_params["iteration"] = 0
+band_interpolation(svo_mf, winter_params)
+
+mpi.barrier()
+
+# Plotting
+if mpi.root():
+  fig, ax = plt.subplots(1, figsize=(7,5.5), dpi=80)
+  plot_utils.band_plot(ax, "svo.qpgw.mbpt.h5", iteration=0, color='tab:blue', linestyle="--",  
+                       linewidth=2.0, label='PBE', fontsize=16)
+  plot_utils.band_plot(ax, "svo.qpgw.mbpt.h5", iteration=1, color='tab:red', linestyle="-", 
+                       linewidth=2.0, label='qpgw', fontsize=16)
+  ax.axhline(y=0, color = 'black', linestyle = '-', linewidth=2.0, alpha=0.5)
+  #ax.set_ylim(-10.884, 10.884)
+  ax.legend(loc=1, fontsize=16)
+  plt.tight_layout()
+  
+  plt.savefig("svo.qpgw.png", format="png")
+
+mpi.barrier()

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -238,7 +238,7 @@ void run(mpi3::communicator &comm, InputParser &parser)
       app_error("calculation type: {} not implemented yet \n",cname.c_str());
 
     } else if (cname == "hf" or cname == "qphf" or cname == "rpa" or cname == "gw" or cname == "qpgw" or cname == "gw_dca"
-               or cname == "evgw0" or cname == "gf2") {
+               or cname == "evgw" or cname == "gf2") {
 
       // all based on mbpt, lump together
       ptree pt = it.second;

--- a/src/methods/GW/tests/test_chol_gw.cpp
+++ b/src/methods/GW/tests/test_chol_gw.cpp
@@ -56,11 +56,11 @@ namespace bdft_tests {
 
       chol_reader_t chol(mf, methods::make_chol_reader_ptree(1e-10, mf->ecutrho(), 32, "./"));
       auto eri = mb_eri_t(chol, chol);
-      qp_context_t qp_context("sc", "pade", 18, 0.0001, 1e-8);
+      qp_params_t qp_params("sc", "pade", 18, 0.0001, 1e-8, "evscf");
       iter_scf::iter_scf_t iter_sol("damping");
       MBState mb_state(mpi_context, ft, output);
-      [[maybe_unused]] double e_hf = qp_scf_loop<true>(
-          mb_state, eri, ft, qp_context,
+      [[maybe_unused]] double e_hf = qp_scf_loop(
+          mb_state, eri, ft, qp_params,
           solvers::mb_solver_t(&hf,&gw,&scr_eri), &iter_sol, 1, false, 1e-8);
       mpi_context->comm.barrier();
 

--- a/src/methods/GW/tests/test_thc_gw.cpp
+++ b/src/methods/GW/tests/test_thc_gw.cpp
@@ -57,10 +57,10 @@ namespace bdft_tests {
       thc_reader_t thc(mf, make_thc_reader_ptree(mf->nbnd()*24, "", "incore", "", "bdft",
                                                  1e-10, mf->ecutrho(), 1, 1024));
       auto eri = mb_eri_t(thc, thc);
-      qp_context_t qp_context("sc", "pade", 18, 0.0001, 1e-8);
+      qp_params_t qp_params("sc", "pade", 18, 0.0001, 1e-8, "evscf");
       iter_scf::iter_scf_t iter_sol("damping");
       MBState mb_state(mpi_context, ft, output);
-      [[maybe_unused]] double e_hf = qp_scf_loop<true>(mb_state, eri, ft, qp_context,
+      [[maybe_unused]] double e_hf = qp_scf_loop(mb_state, eri, ft, qp_params,
                                       solvers::mb_solver_t(&hf,&gw,&scr_eri), &iter_sol, 1, false, 1e-8);
       mpi_context->comm.barrier();
 

--- a/src/methods/HF/tests/test_thc_hf.cpp
+++ b/src/methods/HF/tests/test_thc_hf.cpp
@@ -198,12 +198,12 @@ namespace bdft_tests {
       thc_reader_t thc(mf, make_thc_reader_ptree(mf->nbnd()*20, "", "incore", "", "bdft", 1e-10, mf->ecutrho(),
                        1, 1024));
       auto eri = mb_eri_t(thc, thc);
-      qp_context_t qp_context;
+      qp_params_t qp_params;
       iter_scf::iter_scf_t iter_sol("damping");
       MBState mb_state(mpi_context, ft, "bdft");
-      double e_hf = qp_scf_loop<false>(mb_state, eri, ft, qp_context,
-                                       solvers::mb_solver_t(&hf), &iter_sol,
-                                       1, false, 1e-9);
+      double e_hf = qp_scf_loop(mb_state, eri, ft, qp_params,
+                                solvers::mb_solver_t(&hf), &iter_sol,
+                                1, false, 1e-9);
       VALUE_EQUAL(e_hf, -4.2818278244126935, 1e-5);
 
       nda::array<ComplexType, 3> E_ska;
@@ -340,12 +340,12 @@ namespace bdft_tests {
       thc_reader_t thc(mf, make_thc_reader_ptree(mf->nbnd()*25, "", "incore", "", "bdft",
                                                  1e-10, mf->ecutrho(), 1, 1024));
       auto eri = mb_eri_t(thc, thc);
-      qp_context_t qp_context;
+      qp_params_t qp_params;
       iter_scf::iter_scf_t iter_sol("damping");
       MBState mb_state(mpi_context, ft, "bdft");
-      double e_hf = qp_scf_loop<false>(mb_state, eri, ft, qp_context,
-                                       solvers::mb_solver_t(&hf), &iter_sol,
-                                       1, false, 1e-9);
+      double e_hf = qp_scf_loop(mb_state, eri, ft, qp_params,
+                                solvers::mb_solver_t(&hf), &iter_sol,
+                                1, false, 1e-9);
       VALUE_EQUAL(e_hf, 0.8730537612681228, 1e-6);
       mpi_context->comm.barrier();
 

--- a/src/methods/MBPT_drivers.cpp
+++ b/src/methods/MBPT_drivers.cpp
@@ -281,19 +281,20 @@ void mbpt(std::string solver_type, eri_t &eri, ptree const& pt)
       iter_solver = nullptr;
     }
     MBState mb_state(mpi, ft, output);
-    qp_context_t qp_context;
-    qp_scf_loop<false>(mb_state, eri, ft, qp_context, mb_solver_t(&hf), iter_solver.get(),
-                       niter, restart, conv_thr);
+    qp_params_t qp_params;
+    qp_scf_loop(mb_state, eri, ft, qp_params, mb_solver_t(&hf), iter_solver.get(),
+                niter, restart, conv_thr);
 
-  } else if (solver_type == "evgw0") {
+  } else if (solver_type == "evgw") {
 
+    auto keep_scr_coulomb_fixed = io::get_value_with_default<bool>(pt,"keep_scr_coulomb_fixed", false);
     auto qp_type = io::get_value_with_default<std::string>(pt,"qp_type","sc");
     auto ac_alg  = io::get_value_with_default<std::string>(pt,"ac_alg","pade");
-    auto eta     = io::get_value_with_default<double>(pt,"eta",0.0001);
+    auto eta     = io::get_value_with_default<double>(pt,"eta",1.0/ft.beta());
     auto Nfit    = io::get_value_with_default<int>(pt,"Nfit",18);
     io::tolower(ac_alg);
     io::tolower(qp_type);
-    qp_context_t qp_context(qp_type, ac_alg, Nfit, eta, conv_thr);
+    qp_params_t qp_params(qp_type, ac_alg, Nfit, eta, conv_thr, "evscf", keep_scr_coulomb_fixed);
     if (io::get_value_with_default<bool>(pt,"iter_alg.enable", true)) {
       iter_solver = std::make_unique<iter_scf::iter_scf_t>(iter_scf::make_iter_scf(pt));
     } else {
@@ -302,20 +303,20 @@ void mbpt(std::string solver_type, eri_t &eri, ptree const& pt)
     solvers::scr_coulomb_t scr_eri(&ft, "rpa", div_treatment);
     solvers::gw_t gw(&ft, div_treatment, output);
     MBState mb_state(mpi, ft, output);
-    qp_scf_loop<true>(mb_state, eri, ft, qp_context, mb_solver_t(&hf,&gw,&scr_eri), iter_solver.get(),
-                      niter, restart, conv_thr);
+    qp_scf_loop(mb_state, eri, ft, qp_params, mb_solver_t(&hf,&gw,&scr_eri), iter_solver.get(),
+                niter, restart, conv_thr);
 
   } else if (solver_type == "qpgw") {
 
     auto ac_alg  = io::get_value_with_default<std::string>(pt,"ac_alg","pade");
-    auto eta     = io::get_value_with_default<double>(pt,"eta",0.0001);
+    auto eta     = io::get_value_with_default<double>(pt,"eta",1.0/ft.beta());
     auto Nfit    = io::get_value_with_default<int>(pt,"Nfit",18);
     auto off_diag_mode = io::get_value_with_default<std::string>(pt,"off_diag_mode","fermi");
     io::tolower(ac_alg);
     io::tolower(off_diag_mode);
     utils::check(off_diag_mode=="fermi" or off_diag_mode=="qp_energy",
                  "unknown off_diag_mode: {}. Valid options are \"fermi\" and \"qp_energy\"");
-    qp_context_t qp_context("sc", ac_alg, Nfit, eta, 1e-8, off_diag_mode);
+    qp_params_t qp_params("sc", ac_alg, Nfit, eta, 1e-8, "qpscf", false, off_diag_mode);
     if (io::get_value_with_default<bool>(pt,"iter_alg.enable", true)) {
       iter_solver = std::make_unique<iter_scf::iter_scf_t>(iter_scf::make_iter_scf(pt));
     } else {
@@ -324,8 +325,8 @@ void mbpt(std::string solver_type, eri_t &eri, ptree const& pt)
     solvers::scr_coulomb_t scr_eri(&ft, "rpa", div_treatment);
     solvers::gw_t gw(&ft, div_treatment, output);
     MBState mb_state(mpi, ft, output);
-    qp_scf_loop<false>(mb_state, eri, ft, qp_context, mb_solver_t(&hf,&gw,&scr_eri), iter_solver.get(),
-                       niter, restart, conv_thr);
+    qp_scf_loop(mb_state, eri, ft, qp_params, mb_solver_t(&hf,&gw,&scr_eri), iter_solver.get(),
+                niter, restart, conv_thr);
 
   } else
     APP_ABORT("mbpt: Unknown solver type: {}",solver_type);
@@ -439,11 +440,11 @@ void downfolding_1e(std::shared_ptr<mf::MF> mf, ptree const& pt) {
     io::tolower(off_diag_mode);
     utils::check(off_diag_mode=="fermi" or off_diag_mode=="qp_energy",
                  "unknown off_diag_mode: {}. Valid options are \"fermi\" and \"qp_energy\"");
-    qp_context_t qp_context("sc", ac_alg,
-                            io::get_value_with_default<int>(pt,"Nfit",30),
-                            io::get_value_with_default<double>(pt,"eta",1e-6),
-                            1e-8, off_diag_mode);
-    embed.downfolding(mb_state, pt, &qp_context);
+    qp_params_t qp_params("sc", ac_alg,
+                io::get_value_with_default<int>(pt,"Nfit",30),
+                io::get_value_with_default<double>(pt,"eta",1.0/ft.beta()),
+                1e-8, "qpscf", false, off_diag_mode);
+    embed.downfolding(mb_state, pt, &qp_params);
   } else {
     embed.downfolding(mb_state, pt);
   }
@@ -765,15 +766,15 @@ void gw_downfold(eri_t &eri, ptree &pt) {
   io::tolower(off_diag_mode);
   utils::check(off_diag_mode=="fermi" or off_diag_mode=="qp_energy",
                "unknown off_diag_mode: {}. Valid options are \"fermi\" and \"qp_energy\"");
-  qp_context_t qp_context(
+  qp_params_t qp_params(
       "sc", ac_alg,
       io::get_value_with_default<int>(pt,"Nfit",30),
-      io::get_value_with_default<double>(pt,"eta",1e-6),
-      1e-8, off_diag_mode);
+      io::get_value_with_default<double>(pt,"eta",1.0/ft.beta()),
+      1e-8, "qpscf", false, off_diag_mode);
   embed_t embed(*mf, wannier_file, trans_home_cell);
   pt.put("update_dc", true);
   pt.put("dc_type", "gw");
-  embed.downfolding(mb_state, pt, &qp_context, "model_static");
+  embed.downfolding(mb_state, pt, &qp_params, "model_static");
 }
 
 void dmft_embed_with_projector_from_h5(std::shared_ptr<mf::MF> mf, ptree const& pt,

--- a/src/methods/SCF/CMakeLists.txt
+++ b/src/methods/SCF/CMakeLists.txt
@@ -1,7 +1,7 @@
 #//////////////////////////////////////////////////////////////////////////////////////
 #//////////////////////////////////////////////////////////////////////////////////////
 
-add_library(scf_lib simple_dyson.cpp dca_dyson.cpp dca_dyson.h scf_driver.hpp scf_driver.cpp rpa.cpp scf_common.hpp scf_common.cpp qp_scf_common.cpp mb_solver_t.h qp_context.h)
+add_library(scf_lib simple_dyson.cpp dca_dyson.cpp dca_dyson.h scf_driver.hpp scf_driver.cpp rpa.cpp scf_common.hpp scf_common.cpp qp_scf_common.cpp mb_solver_t.h qp_params_t.h)
 target_link_libraries(scf_lib PUBLIC utils numerics meanfield hamilt ac_lib hf_lib gw_lib gf2_lib methods_tools_lib)
 install(TARGETS scf_lib
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/src/methods/SCF/qp_params_t.h
+++ b/src/methods/SCF/qp_params_t.h
@@ -24,14 +24,25 @@
 
 namespace methods {
 
-struct qp_context_t {
+struct qp_params_t {
   std::string qp_type = "sc";
   std::string ac_alg = "pade";
   int Nfit = 18;
   double eta = 0.0001;
   double tol = 1e-8;
 
+  // SCF mode selector:
+  // - evscf: update only QP energies and keep QP wavefunctions fixed to mean-field ones.
+  // - qpscf: update both QP energies and QP wavefunctions.
+  std::string qp_scf_mode = "qpscf";
+
+  // whether to update dynamically screened interaction W in evscf.
+  bool keep_scr_coulomb_fixed = false;
+
   // off-diagonal mode defined in T. Kotani et. al., Phys. Rev. B 76, 165106 (2007)
+  // "fermi": evaluate off-diagonal elements of self-energy at the Fermi level;
+  // "qp_energy": evaluate off-diagonal elements of self-energy at the quasiparticle energy
+  // (defined as the average of the two diagonal elements)
   std::string off_diag_mode = "fermi";
 };
 

--- a/src/methods/SCF/qp_scf_common.cpp
+++ b/src/methods/SCF/qp_scf_common.cpp
@@ -506,9 +506,11 @@ auto qp_approx(const sArray_t<Array_view_5D_t> &sSigma_tskij,
       double eps_b = sE_ska.local()(s, k, b).real() - mu;
       sVcorr_skij.local()(s, k, a, b) = 0.5 * ( AC.evaluate(ComplexType(eps_a, qp_params.eta), I)
                                                  + AC.evaluate(ComplexType(eps_b, qp_params.eta), I) );
-    } else {
+    } else if (qp_params.off_diag_mode == "fermi") {
       double eps_a = (a == b)? sE_ska.local()(s, k, a).real() - mu : 0.0;
       sVcorr_skij.local()(s, k, a, b) = AC.evaluate(ComplexType(eps_a, qp_params.eta), I);
+    } else {
+      utils::check(false, "qp_approx: unknown off-diagonal mode: {}", qp_params.off_diag_mode);
     }
   }
   sVcorr_skij.win().fence();
@@ -582,7 +584,7 @@ void add_qpscf_vcorr(MBState &mb_state,
   if (mpi->node_comm.root()) sHeff_skij.local() += sVcorr_skij.local();
   mpi->comm.barrier();
  
-  // deallocatation
+  // deallocation
   mb_state.dW_qtPQ.reset();
   mb_state.sG_tskij.reset();
   mb_state.sSigma_tskij.reset();

--- a/src/methods/SCF/qp_scf_common.cpp
+++ b/src/methods/SCF/qp_scf_common.cpp
@@ -173,7 +173,7 @@ void solve_qp_eqn(sArray_t<Array_view_3D_t> &sE_ska,
                   const sArray_t<Array_view_4D_t> &sVhf_skij,
                   const sArray_t<Array_view_4D_t> &sMO_skia,
                   double mu,
-                  const imag_axes_ft::IAFT &FT, qp_context_t &qp_context) {
+                  const imag_axes_ft::IAFT &FT, qp_params_t &qp_params) {
   using math::shm::make_shared_array;
   using math::nda::make_distributed_array;
   using local_Array_4D_t = nda::array<ComplexType, 4>;
@@ -271,49 +271,49 @@ void solve_qp_eqn(sArray_t<Array_view_3D_t> &sE_ska,
       return std::make_tuple(s_rng.first()+s_loc, k_rng.first()+k_loc, a_rng.first()+a_loc);
     };
 
-    analyt_cont::AC_t AC(qp_context.ac_alg);
+    analyt_cont::AC_t AC(qp_params.ac_alg);
     auto n_to_iw = nda::map([&](int n) { return FT.omega(n); });
     nda::array<ComplexType, 1> iw_mesh(n_to_iw(FT.wn_mesh()));
 
     app_log(2, "\n* Solving quasiparticle equation for given Sigma(iw): ");
     app_log(2, "  - processor grid for quasi-particle equation: (s, k, a) = ({}, {}, {})", 1, nkpools, np_a);
-    app_log(2, "  - quasi-particle equation algorithm:          {}", qp_context.qp_type);
-    app_log(2, "  - ac algorithm:                               {}", qp_context.ac_alg);
-    app_log(2, "  - eta:                                        {}", qp_context.eta);
-    app_log(2, "  - tolerance for quasi-particle equation:      {}\n", qp_context.tol);
-    AC.init(iw_mesh, Sigma_loc_2D, qp_context.Nfit);
-    if (qp_context.qp_type == "sc" or qp_context.qp_type == "sc_bisection") {
+    app_log(2, "  - quasi-particle equation algorithm:          {}", qp_params.qp_type);
+    app_log(2, "  - ac algorithm:                               {}", qp_params.ac_alg);
+    app_log(2, "  - eta:                                        {}", qp_params.eta);
+    app_log(2, "  - tolerance for quasi-particle equation:      {}\n", qp_params.tol);
+    AC.init(iw_mesh, Sigma_loc_2D, qp_params.Nfit);
+    if (qp_params.qp_type == "sc" or qp_params.qp_type == "sc_bisection") {
       double res;
       for (size_t I = 0; I < dim1; ++I) {
         std::tie(E_loc_1D(I), res) =
-            qp_eqn_bisection(Vhf_loc_1D(I).real(), AC, I, mu, E_loc_1D(I).real(), qp_context.tol, qp_context.eta);
+            qp_eqn_bisection(Vhf_loc_1D(I).real(), AC, I, mu, E_loc_1D(I).real(), qp_params.tol, qp_params.eta);
       }
-    } else if (qp_context.qp_type == "sc_newton") {
+    } else if (qp_params.qp_type == "sc_newton") {
       bool conv;
       double res;
       for (size_t I = 0; I < dim1; ++I) {
         std::tie(E_loc_1D(I), res, conv) =
-            qp_eqn_secant(Vhf_loc_1D(I).real(), AC, I, mu, E_loc_1D(I).real(), 400, qp_context.tol, qp_context.eta);
+            qp_eqn_secant(Vhf_loc_1D(I).real(), AC, I, mu, E_loc_1D(I).real(), 400, qp_params.tol, qp_params.eta);
         if (!conv) {
           auto [is, ik, ia] = I_to_ska(I);
           app_warning("secant method fails to converge at (s,k,a) = ({},{},{}); residual = {}", is, ik, ia, res);
         }
       }
-    } else if (qp_context.qp_type == "linearized") {
+    } else if (qp_params.qp_type == "linearized") {
       for (size_t I = 0; I < dim1; ++I) {
-        E_loc_1D(I) = qp_eqn_linearized(Vhf_loc_1D(I).real(), AC, I, mu, E_loc_1D(I).real(), qp_context.eta);
+        E_loc_1D(I) = qp_eqn_linearized(Vhf_loc_1D(I).real(), AC, I, mu, E_loc_1D(I).real(), qp_params.eta);
       }
-    } else if (qp_context.qp_type == "spectral") {
+    } else if (qp_params.qp_type == "spectral") {
       bool conv;
       for (size_t I = 0; I < dim1; ++I) {
-        std::tie(E_loc_1D(I), conv) = qp_eqn_spectral(Vhf_loc_1D(I).real(), AC, I, mu, E_loc_1D(I).real(), qp_context.tol, qp_context.eta);
+        std::tie(E_loc_1D(I), conv) = qp_eqn_spectral(Vhf_loc_1D(I).real(), AC, I, mu, E_loc_1D(I).real(), qp_params.tol, qp_params.eta);
         if (!conv) {
           auto [is, ik, ia] = I_to_ska(I);
           app_warning("spectral method fails to converge at (s,k,a) = ({},{},{})", is, ik, ia);
         }
       }
     } else {
-      utils::check(false, "add_evscf_vcorr: unknown type of qp equation: {}", qp_context.qp_type);
+      utils::check(false, "solve_qp_eqn: unknown type of qp equation: {}", qp_params.qp_type);
     }
   }
   dSigma_wska.reset();
@@ -331,19 +331,22 @@ void solve_qp_eqn(sArray_t<Array_view_3D_t> &sE_ska,
   comm->barrier();
 }
 
-template<bool update_W, typename eri_t, typename corr_solver_t>
+template<typename eri_t, typename corr_solver_t>
 void add_evscf_vcorr(MBState &mb_state,
-                     sArray_t<Array_view_3D_t> &sE_ska,
-                     const sArray_t<Array_view_4D_t> &sMO_skia,
                      double mu,
                      solvers::mb_solver_t<corr_solver_t> &mb_solver,
                      eri_t &eri,
                      const imag_axes_ft::IAFT &FT,
-                     qp_context_t &qp_context) {
+                     qp_params_t &qp_params, 
+                     bool fixed_w) {
   using math::shm::make_shared_array;
 
-  auto& sHeff_skij = mb_state.sF_skij.value();
   auto mpi = eri.mpi();
+
+  auto& sHeff_skij = mb_state.sHeff_skij.value();
+  auto& sMO_skia = mb_state.sMO_skia.value();
+  auto& sE_ska = mb_state.sE_ska.value();
+  
   auto [ns, nkpts, nbnd, nbnd2] = sHeff_skij.shape();
   auto nt = FT.nt_f();
 
@@ -353,19 +356,29 @@ void add_evscf_vcorr(MBState &mb_state,
   {
     update_G(mb_state.sG_tskij.value(), sMO_skia, sE_ska, mu, FT);
     FT.check_leakage(mb_state.sG_tskij.value(), imag_axes_ft::fermion, "Green's function");
-    ///
-    if constexpr (update_W) {
+    
+    // update dyanmically screened interaction in mb_state if necessary.
+    if (not fixed_w or not mb_state.dW_qtPQ.has_value()) {
       utils::check(mb_solver.scr_eri!=nullptr, "add_evscf_vcorr: mb_solver.scr_eri == nullptr when update_W is true.");
       mb_solver.scr_eri->update_w(mb_state, eri, mb_solver.corr->iter());
     }
+    
     mb_solver.corr->evaluate(mb_state, eri);
     FT.check_leakage(mb_state.sSigma_tskij.value(), imag_axes_ft::fermion, "Self-energy");
     mpi->comm.barrier();
+
+    // deallocate dynamically screened interaction if it is not fixed for the next iteration.
+    if (not fixed_w) {
+      mb_state.dW_qtPQ.reset();
+    }
   }
-  solve_qp_eqn(sE_ska, mb_state.sSigma_tskij.value(), sHeff_skij, sMO_skia, mu, FT, qp_context);
+
+  // Solve the QP equation to get new QP energies. 
+  solve_qp_eqn(sE_ska, mb_state.sSigma_tskij.value(), sHeff_skij, sMO_skia, mu, FT, qp_params);
   mb_state.sG_tskij.reset();
   mb_state.sSigma_tskij.reset();
 
+  /** Update sHeff_skij with the new QP energies while keeping MO coefficients the same */
   // Basis transformation back to the primary basis.
   auto sMOinv_skai = make_shared_array<Array_view_4D_t>(*mpi, {ns, nkpts, nbnd, nbnd});
   sMOinv_skai.win().fence();
@@ -398,7 +411,7 @@ void add_evscf_vcorr(MBState &mb_state,
 auto qp_approx(const sArray_t<Array_view_5D_t> &sSigma_tskij,
                const sArray_t<Array_view_4D_t> &sMO_skia,
                const sArray_t<Array_view_3D_t> &sE_ska, double mu,
-               const imag_axes_ft::IAFT &FT, qp_context_t &qp_context)
+               const imag_axes_ft::IAFT &FT, qp_params_t &qp_params)
                -> sArray_t<Array_view_4D_t> {
   using math::shm::make_shared_array;
   using math::nda::make_distributed_array;
@@ -472,32 +485,30 @@ auto qp_approx(const sArray_t<Array_view_5D_t> &sSigma_tskij,
     return std::make_tuple(s_rng.first()+s_loc, k_rng.first()+k_loc, a_rng.first()+a_loc, b_rng.first()+b_loc);
   };
 
-  analyt_cont::AC_t AC(qp_context.ac_alg);
+  analyt_cont::AC_t AC(qp_params.ac_alg);
   auto n_to_iw = nda::map([&](int n) { return FT.omega(n); });
   nda::array<ComplexType, 1> iw_mesh(n_to_iw(FT.wn_mesh()));
 
   app_log(2, "\n* Applying the static approximation (Phys. Rev. Lett. 93, 126406) to Sigma(w): ");
   app_log(2, "  - processor grid for V_QPGW : (s, k, a, b) = ({}, {}, {})", 1, nkpools, np_a, np_b);
-  app_log(2, "  - ac algorithm:               {}", qp_context.ac_alg);
-  app_log(2, "  - eta:                        {}", qp_context.eta);
-  app_log(2, "  - off-diagonal mode:          {}\n", qp_context.off_diag_mode);
+  app_log(2, "  - ac algorithm:               {}", qp_params.ac_alg);
+  app_log(2, "  - eta:                        {}", qp_params.eta);
+  app_log(2, "  - off-diagonal mode:          {}\n", qp_params.off_diag_mode);
   auto Sigma_loc_2D = nda::reshape(dSigma_wskab.local(), std::array<long, 2>{nw, dim1});
-  AC.init(iw_mesh, Sigma_loc_2D, qp_context.Nfit);
+  AC.init(iw_mesh, Sigma_loc_2D, qp_params.Nfit);
 
   auto sVcorr_skij = make_shared_array<Array_view_4D_t>(*comm, *internode_comm, *node_comm, {ns, nkpts, nbnd, nbnd});
   sVcorr_skij.win().fence();
   for (size_t I = 0; I < dim1; ++I) {
     auto [s, k, a, b] = I_to_skab(I);
-    if (qp_context.off_diag_mode == "qp_energy") {
+    if (qp_params.off_diag_mode == "qp_energy") {
       double eps_a = sE_ska.local()(s, k, a).real() - mu;
       double eps_b = sE_ska.local()(s, k, b).real() - mu;
-      sVcorr_skij.local()(s, k, a, b) = 0.5 * ( AC.evaluate(ComplexType(eps_a, qp_context.eta), I)
-                                                 + AC.evaluate(ComplexType(eps_b, qp_context.eta), I) );
-    } else if (qp_context.off_diag_mode == "fermi") {
-      double eps_a = (a == b)? sE_ska.local()(s, k, a).real() - mu : 0.0;
-      sVcorr_skij.local()(s, k, a, b) = AC.evaluate(ComplexType(eps_a, qp_context.eta), I);
+      sVcorr_skij.local()(s, k, a, b) = 0.5 * ( AC.evaluate(ComplexType(eps_a, qp_params.eta), I)
+                                                 + AC.evaluate(ComplexType(eps_b, qp_params.eta), I) );
     } else {
-      utils::check(false, "unknown off_diag_mode: {}. Valid options are \"fermi\" and \"qp_energy\"");
+      double eps_a = (a == b)? sE_ska.local()(s, k, a).real() - mu : 0.0;
+      sVcorr_skij.local()(s, k, a, b) = AC.evaluate(ComplexType(eps_a, qp_params.eta), I);
     }
   }
   sVcorr_skij.win().fence();
@@ -539,38 +550,40 @@ auto qp_approx(const sArray_t<Array_view_5D_t> &sSigma_tskij,
 
 template<typename eri_t, typename corr_solver_t>
 void add_qpscf_vcorr(MBState &mb_state,
-                     const sArray_t<Array_view_3D_t> &sE_ska,
-                     const sArray_t<Array_view_4D_t> &sMO_skia,
                      double mu,
                      solvers::mb_solver_t<corr_solver_t> &mb_solver,
                      eri_t &eri,
                      const imag_axes_ft::IAFT &FT,
-                     qp_context_t &qp_context) {
+                     qp_params_t &qp_params) {
   using math::shm::make_shared_array;
 
-  auto& sVhf_skij = mb_state.sF_skij.value();
+  auto& sHeff_skij = mb_state.sHeff_skij.value();
+  auto& sMO_skia = mb_state.sMO_skia.value();
+  auto& sE_ska = mb_state.sE_ska.value();
   auto mpi = eri.mpi();
-  //auto comm = sVhf_skij.communicator();
-  //auto internode_comm = sVhf_skij.internode_comm();
-  //auto node_comm = sVhf_skij.node_comm();
-  auto [ns, nkpts, nbnd, nbnd2] = sVhf_skij.shape();
+  auto [ns, nkpts, nbnd, nbnd2] = sHeff_skij.shape();
   auto nt = FT.nt_f();
 
   mb_state.sSigma_tskij.emplace(make_shared_array<Array_view_5D_t>(*mpi, {nt, ns, nkpts, nbnd, nbnd}));
   mb_state.sG_tskij.emplace(make_shared_array<Array_view_5D_t>(*mpi, {nt, ns, nkpts, nbnd, nbnd}));
   update_G(mb_state.sG_tskij.value(), sMO_skia, sE_ska, mu, FT);
   FT.check_leakage(mb_state.sG_tskij.value(), imag_axes_ft::fermion, "Green's function");
-  // screen interaction
+  
+  // compute screen interaction
   utils::check(mb_solver.scr_eri!=nullptr, "add_qpscf_vcorr: mb_solver.scr_eri == nullptr.");
   mb_solver.scr_eri->update_w(mb_state, eri, mb_solver.corr->iter());
-  // evaluate self-energy in the primary basis
+  
+  // compute dynamic self-energy in the primary basis
   mb_solver.corr->evaluate(mb_state, eri);
   FT.check_leakage(mb_state.sSigma_tskij.value(), imag_axes_ft::fermion, "Self-energy");
-  mpi->comm.barrier();
 
-  auto sVcorr_skij = qp_approx(mb_state.sSigma_tskij.value(),  sMO_skia, sE_ska, mu, FT, qp_context);
-  if (mpi->node_comm.root()) sVhf_skij.local() += sVcorr_skij.local();
+  // Add the correlation contribution to the QP Hamiltonian.
+  auto sVcorr_skij = qp_approx(mb_state.sSigma_tskij.value(),  sMO_skia, sE_ska, mu, FT, qp_params);
+  if (mpi->node_comm.root()) sHeff_skij.local() += sVcorr_skij.local();
   mpi->comm.barrier();
+ 
+  // deallocatation
+  mb_state.dW_qtPQ.reset();
   mb_state.sG_tskij.reset();
   mb_state.sSigma_tskij.reset();
   mpi->comm.barrier();
@@ -902,19 +915,11 @@ void write_mf_data(mf::MF &mf, const imag_axes_ft::IAFT &ft,
 
 template double update_mu(double, const mf::MF&, const sArray_t<Array_view_3D_t>&, double, double);
 
-template void add_evscf_vcorr<true>(MBState&, sArray_t<Array_view_3D_t>&,
-    const sArray_t<Array_view_4D_t>&, double, solvers::mb_solver_t<>&, thc_reader_t&, const imag_axes_ft::IAFT&, qp_context_t&);
-template void add_evscf_vcorr<true>(MBState&, sArray_t<Array_view_3D_t>&,
-    const sArray_t<Array_view_4D_t>&, double, solvers::mb_solver_t<>&, chol_reader_t&, const imag_axes_ft::IAFT&, qp_context_t&);
-template void add_evscf_vcorr<false>(MBState&, sArray_t<Array_view_3D_t>&,
-    const sArray_t<Array_view_4D_t>&, double, solvers::mb_solver_t<>&, thc_reader_t&, const imag_axes_ft::IAFT&, qp_context_t&);
-template void add_evscf_vcorr<false>(MBState&, sArray_t<Array_view_3D_t>&,
-    const sArray_t<Array_view_4D_t>&, double, solvers::mb_solver_t<>&, chol_reader_t&, const imag_axes_ft::IAFT&, qp_context_t&);
+template void add_evscf_vcorr(MBState&, double, solvers::mb_solver_t<>&, thc_reader_t&, const imag_axes_ft::IAFT&, qp_params_t&, bool);
+template void add_evscf_vcorr(MBState&, double, solvers::mb_solver_t<>&, chol_reader_t&, const imag_axes_ft::IAFT&, qp_params_t&, bool);
 
-template void add_qpscf_vcorr(MBState&, const sArray_t<Array_view_3D_t>&, const sArray_t<Array_view_4D_t>&,
-    double, solvers::mb_solver_t<>&, thc_reader_t&, const imag_axes_ft::IAFT&, qp_context_t&);
-template void add_qpscf_vcorr(MBState&, const sArray_t<Array_view_3D_t>&, const sArray_t<Array_view_4D_t>&,
-    double, solvers::mb_solver_t<>&, chol_reader_t&, const imag_axes_ft::IAFT&, qp_context_t&);
+template void add_qpscf_vcorr(MBState&, double, solvers::mb_solver_t<>&, thc_reader_t&, const imag_axes_ft::IAFT&, qp_params_t&);
+template void add_qpscf_vcorr(MBState&, double, solvers::mb_solver_t<>&, chol_reader_t&, const imag_axes_ft::IAFT&, qp_params_t&);
 
 template double qp_eqn_linearized(double, analyt_cont::AC_t &, long, double, double, double);
 template std::tuple<double,double> qp_eqn_bisection(double, analyt_cont::AC_t &, long, double, double, double, double);

--- a/src/methods/SCF/scf_common.hpp
+++ b/src/methods/SCF/scf_common.hpp
@@ -137,7 +137,7 @@ double compute_Nelec(double mu, const mf::MF &mf, const sArray_t<Array_view_3D_t
  * @param sMO_skia      - [INPUT] MO coefficients
  * @param mu            - [INPUT] chemical potential
  * @param FT            - [INPUT] Fourier transform driver on imaginary axes
- * @param qp_params    - [INPUT] setups for quasi-paritcle eqn
+ * @param qp_params    - [INPUT] setups for quasiparticle eqn
  */
 void solve_qp_eqn(sArray_t<Array_view_3D_t> &sE_ska,
                   const sArray_t<Array_view_5D_t> &sSigma_tskij,

--- a/src/methods/SCF/scf_common.hpp
+++ b/src/methods/SCF/scf_common.hpp
@@ -28,7 +28,7 @@
 
 #include "mean_field/MF.hpp"
 #include "utilities/mpi_context.h"
-#include "methods/SCF/qp_context.h"
+#include "methods/SCF/qp_params_t.h"
 #include "methods/SCF/mb_solver_t.h"
 #include "methods/mb_state/mb_state.hpp"
 #include "numerics/imag_axes_ft/IAFT.hpp"
@@ -137,14 +137,14 @@ double compute_Nelec(double mu, const mf::MF &mf, const sArray_t<Array_view_3D_t
  * @param sMO_skia      - [INPUT] MO coefficients
  * @param mu            - [INPUT] chemical potential
  * @param FT            - [INPUT] Fourier transform driver on imaginary axes
- * @param qp_context    - [INPUT] setups for quasi-paritcle eqn
+ * @param qp_params    - [INPUT] setups for quasi-paritcle eqn
  */
 void solve_qp_eqn(sArray_t<Array_view_3D_t> &sE_ska,
                   const sArray_t<Array_view_5D_t> &sSigma_tskij,
                   const sArray_t<Array_view_4D_t> &sVhf_skij,
                   const sArray_t<Array_view_4D_t> &sMO_skia,
                   double mu,
-                  const imag_axes_ft::IAFT &FT, qp_context_t &qp_context);
+                  const imag_axes_ft::IAFT &FT, qp_params_t &qp_params);
 
 /**
  * Given a dynamic self-energy in the primary basis, return the static approximation (Phys. Rev. Lett. 96, 226402 (2006)) of it
@@ -158,48 +158,43 @@ void solve_qp_eqn(sArray_t<Array_view_3D_t> &sE_ska,
  * @param sE_ska       - [INPUT] quasi-particle energies
  * @param mu           - [INPUT] chemical potential
  * @param FT           - [INPUT] Fourier transform driver on imaginary axes
- * @param qp_context   - [INPUT] setups for quasi-paritcle eqn, including mode "qp_energy" or mode "fermi"
+ * @param qp_params   - [INPUT] setups for quasi-paritcle eqn, including mode "qp_energy" or mode "fermi"
  * @return static approximation to the dynamic self-energy in the primary basis
  */
 auto qp_approx(const sArray_t<Array_view_5D_t> &sSigma_tskij,
                const sArray_t<Array_view_4D_t> &sMO_skia,
                const sArray_t<Array_view_3D_t> &sE_ska, double mu,
-               const imag_axes_ft::IAFT &FT, qp_context_t &qp_context)
+               const imag_axes_ft::IAFT &FT, qp_params_t &qp_params)
   -> sArray_t<Array_view_4D_t>;
 
 /**
  * Given a correlated solver, compute the dynamic self-energy and
- * solve the quasi-particle eqn in the presence of correlated potential V_corr(w) in MO basis
+ * solve the quasi-particle Eqn in the presence of correlated potential V_corr(w) in MO basis
  * Specifically, this functions does the following:
  * 1. compute dynamic self-energy from 'corr_solver'
  * 2. compute diagonals of V_corr(iw) in MO basis
  * 3. solve the quasiparticle equations for e_qp with V_corr(w)
  * 4. compute the new Heff using the new e_qp and MO coefficients
  * 5. update e_qp and Heff in-place
- * @tparam update_W      - whether to evaluate the screened interactions using mb_solver_t
  * @tparam eri_t         - THC-ERI
  * @tparam corr_solver_t - correlated solver
- * @param sHeff_skij     - [INPUT] Hartree-Fock Hamiltonian
- *                         [OUTPUT] effective quasiparticle Hamiltonian:
- * @param sE_ska         - [INPUT] initial qp energies
- *                         [OUTPUT] updated qp energies
- * @param sMO_skia       - [INPUT] MO coefficients
+ * @param mb_state       - [INPUT/OUTPUT] many-body state whose contents will be updated 
+ * @param mu             - [INPUT] chemical potential
  * @param mb_solver      - [INPUT] many-body solver context
  * @param eri            - [INPUT] THC-ERI instance
  * @param FT             - [INPUT] Fourier transform driver on imaginary axes
- * @param mu             - [INPUT] chemical potential
- * @param qp_context     - [INPUT] setups for quasi-paritcle eqn
- * @return new qp energies in share memory sE_ska(ns, nkpts, nbnd)
+ * @param qp_params     - [INPUT] setups for quasi-paritcle eqn
+ * @param fixed_w        - [INPUT] whether to keep the screened interactions fixed from mb_state. 
+ *                         If false, the dynamically screened interaction will be updated at each iteration.
  */
-template<bool update_W=true, typename eri_t, typename corr_solver_t>
+template<typename eri_t, typename corr_solver_t>
 void add_evscf_vcorr(MBState &mb_state,
-                     sArray_t<Array_view_3D_t> &sE_ska,
-                     const sArray_t<Array_view_4D_t> &sMO_skia,
                      double mu,
                      solvers::mb_solver_t<corr_solver_t> &mb_solver,
                      eri_t &eri,
                      const imag_axes_ft::IAFT &FT,
-                     qp_context_t &qp_context);
+                     qp_params_t &qp_params, 
+                     bool fixed_w=false);
 /**
  * Add correlated potential V_corr with static approximation to the effective quasiparticle Hamiltonian
  * The static approximation follows T. Kotani et. al., Phys. Rev. B 76, 165106 (2007) in which
@@ -209,25 +204,21 @@ void add_evscf_vcorr(MBState &mb_state,
  * @tparam keep_W        - whether to keep the screened interactions from corr_solver_t fixed
  * @tparam eri_t         - THC-ERI
  * @tparam corr_solver_t - correlated solver
- * @param sHeff_skij     - [INPUT/OUTPUT] effective quasiparticle Hamiltonian:
- * @param sE_ska         - [INPUT/OUTPUT] qp energies
- * @param sMO_skia       - [INPUT] molecular orbitals coefficients
+ * @param mb_state       - [INPUT/OUTPUT] many-body state whose contents will be updated
  * @param corr_solver    - [INPUT] correlated solver instance
  * @param eri            - [INPUT] THC-ERI instance
  * @param FT             - [INPUT] Fourier transform driver on imaginary axes
  * @param mu             - [INPUT] chemical potential
- * @param qp_context     - [INPUT] setups for quasiparitcle eqn
+ * @param qp_params     - [INPUT] setups for quasiparitcle eqn
  * @return new qp energies in share memory sE_ska(ns, nkpts, nbnd)
  */
 template<typename eri_t, typename corr_solver_t>
 void add_qpscf_vcorr(MBState &mb_state,
-                     const sArray_t<Array_view_3D_t> &sE_ska,
-                     const sArray_t<Array_view_4D_t> &sMO_skia,
                      double mu,
                      solvers::mb_solver_t<corr_solver_t> &mb_solver,
                      eri_t &eri,
                      const imag_axes_ft::IAFT &FT,
-                     qp_context_t &qp_context);
+                     qp_params_t &qp_params);
 
 template<typename function_t>
 double qp_eqn_linearized(double Vhf, function_t &Sigma, long I, double mu, double eps_ks, double eta = 0.0);

--- a/src/methods/SCF/scf_driver.cpp
+++ b/src/methods/SCF/scf_driver.cpp
@@ -64,7 +64,7 @@ auto scf_loop(MBState &mb_state, dyson_type &dyson, eri_t &mb_eri, const imag_ax
     app_log(1, "    - Iteration            = {}", input_iter);
   }
   app_log(1, "  Number of processors     = {} cores per node, {} nodes\n",
-          mpi->comm.size(), mpi->internode_comm.size());
+          mpi->node_comm.size(), mpi->internode_comm.size());
   FT.metadata_log();
 
   Timer.start("SCF_TOTAL");
@@ -266,7 +266,7 @@ double qp_scf_loop(
   app_log(1, "  Checkpoint HDF5             = {}", mb_state.coqui_prefix+".mbpt.h5");
   app_log(1, "  Restart                     = {}", (restart)? "yes" : "no");
   app_log(1, "  Number of processors        = {} cores per node, {} nodes\n",
-          mpi->comm.size(), mpi->internode_comm.size());
+          mpi->node_comm.size(), mpi->internode_comm.size());
   FT.metadata_log();
 
   Timer.start("SCF_TOTAL");
@@ -280,7 +280,7 @@ double qp_scf_loop(
   auto& sE_ska = mb_state.sE_ska.value();
   double mu = 0.0;
 
-  // psuedo potential handler 
+  // pseudopotential handler 
   auto psp = hamilt::make_pseudopot(*mf);
   long init_it = 0;
   if (!restart) {

--- a/src/methods/SCF/scf_driver.cpp
+++ b/src/methods/SCF/scf_driver.cpp
@@ -155,6 +155,8 @@ auto scf_loop(MBState &mb_state, dyson_type &dyson, eri_t &mb_eri, const imag_ax
 
       mb_solver.corr->iter() = output_iter;
       mb_solver.corr->evaluate(mb_state, mb_eri.corr_eri->get());
+      // deallocate mb_state.dW_qtPQ after this since it's only used in the corr solver and can be very large for GW.
+      mb_state.dW_qtPQ.reset();
       mpi->comm.barrier();
     }
 
@@ -230,11 +232,18 @@ auto scf_loop(MBState &mb_state, dyson_type &dyson, eri_t &mb_eri, const imag_ax
 }
 
 
-template<bool evscf_only, typename eri_t, typename corr_solver_t>
-double qp_scf_loop(MBState &mb_state, eri_t &mb_eri, const imag_axes_ft::IAFT& FT,
-                   qp_context_t& qp_context, solvers::mb_solver_t<corr_solver_t> mb_solver,
-                   iter_scf::iter_scf_t *iter_solver,
-                   int niter, bool restart, double conv_tol) {
+template<typename eri_t, typename corr_solver_t>
+double qp_scf_loop(
+  MBState &mb_state, 
+  eri_t &mb_eri, 
+  const imag_axes_ft::IAFT& FT,
+  qp_params_t& qp_params, 
+  solvers::mb_solver_t<corr_solver_t> mb_solver,
+  iter_scf::iter_scf_t *iter_solver,
+  int niter, 
+  bool restart, 
+  double conv_tol) {
+
   using math::shm::make_shared_array;
   utils::TimerManager Timer;
   auto mpi = mb_eri.corr_eri->get().mpi();
@@ -242,43 +251,48 @@ double qp_scf_loop(MBState &mb_state, eri_t &mb_eri, const imag_axes_ft::IAFT& F
   for( auto& v: {"SCF_TOTAL", "CANONICALIZATION", "MBPT_SOLVERS", "ITERATIVE", "WRITE"} ) {
     Timer.add(v);
   }
-  utils::check(qp_context.qp_type=="sc" or qp_context.qp_type=="sc_newton" or
-               qp_context.qp_type=="sc_bisection" or qp_context.qp_type=="linearized" or qp_context.qp_type=="spectral",
-               "qp_scf_loop: unknown qp_type {}: sc or linearized.", qp_context.qp_type);
+  utils::check(qp_params.qp_type=="sc" or qp_params.qp_type=="sc_newton" or
+               qp_params.qp_type=="sc_bisection" or qp_params.qp_type=="linearized" or qp_params.qp_type=="spectral",
+               "qp_scf_loop: unknown qp_type {}: sc or linearized.", qp_params.qp_type);
   // http://patorjk.com/software/taag/#p=display&f=Calvin%20S&t=COQUI%20qp-scf
   app_log(1, "\n"
              "╔═╗╔═╗╔═╗ ╦ ╦╦  ┌─┐ ┌─┐   ┌─┐┌─┐┌─┐\n"
              "║  ║ ║║═╬╗║ ║║  │─┼┐├─┘───└─┐│  ├┤ \n"
              "╚═╝╚═╝╚═╝╚╚═╝╩  └─┘└┴     └─┘└─┘└  \n");
-  app_log(1, "  - maximum iteration number:        {}", niter);
-  app_log(1, "  - eigenvalue scf only:             {}", (evscf_only)? "true" : "false");
-  app_log(1, "  - convergence tolerance:           {}", conv_tol);
-  app_log(1, "  - output:                          {}", mb_state.coqui_prefix+".mbpt.h5");
-  app_log(1, "  - Restart mode:                    {}", (restart)? "yes" : "no");
-  app_log(1, "  - total number processors:         {}", mpi->comm.size());
-  app_log(1, "  - number of nodes:                 {}\n", mpi->internode_comm.size());
-  Timer.start("SCF_TOTAL");
+  app_log(1, "  Maximum iteration number    = {}", niter);
+  app_log(1, "  Eigenvalue scf only         = {}", qp_params.qp_scf_mode == "evscf");
+  app_log(1, "  Keep screened Coulomb fixed = {}", qp_params.keep_scr_coulomb_fixed);
+  app_log(1, "  Convergence tolerance       = {}", conv_tol);
+  app_log(1, "  Checkpoint HDF5             = {}", mb_state.coqui_prefix+".mbpt.h5");
+  app_log(1, "  Restart                     = {}", (restart)? "yes" : "no");
+  app_log(1, "  Number of processors        = {} cores per node, {} nodes\n",
+          mpi->comm.size(), mpi->internode_comm.size());
+  FT.metadata_log();
 
-  mb_state.sF_skij.emplace(make_shared_array<Array_view_4D_t>(*mpi, {mf->nspin(), mf->nkpts_ibz(), mf->nbnd(), mf->nbnd()}));
+  Timer.start("SCF_TOTAL");
+  mb_state.sHeff_skij.emplace(make_shared_array<Array_view_4D_t>(*mpi, {mf->nspin(), mf->nkpts_ibz(), mf->nbnd(), mf->nbnd()}));
   mb_state.sDm_skij.emplace(make_shared_array<Array_view_4D_t>(*mpi, {mf->nspin(), mf->nkpts_ibz(), mf->nbnd(), mf->nbnd()}));
-  auto& sHeff_skij = mb_state.sF_skij.value();
+  mb_state.sMO_skia.emplace(make_shared_array<Array_view_4D_t>(*mpi, {mf->nspin(), mf->nkpts_ibz(), mf->nbnd(), mf->nbnd()}));
+  mb_state.sE_ska.emplace(make_shared_array<Array_view_3D_t>(*mpi, {mf->nspin(), mf->nkpts_ibz(), mf->nbnd()}));
+  auto& sHeff_skij = mb_state.sHeff_skij.value();
   auto& sDm_skij = mb_state.sDm_skij.value();
-  auto sH0_skij = make_shared_array<Array_view_4D_t>(*mpi, {mf->nspin(), mf->nkpts_ibz(), mf->nbnd(), mf->nbnd()});
-  auto sS_skij = make_shared_array<Array_view_4D_t>(*mpi, {mf->nspin(), mf->nkpts_ibz(), mf->nbnd(), mf->nbnd()});
+  auto& sMO_skia = mb_state.sMO_skia.value();
+  auto& sE_ska = mb_state.sE_ska.value();
   double mu = 0.0;
-  // generates a new pseudopot object if not found in mf. Stores shared_ptr in mf and returns it.
+
+  // psuedo potential handler 
   auto psp = hamilt::make_pseudopot(*mf);
-  hamilt::set_H0(*mf, psp.get(), sH0_skij);
-  hamilt::set_ovlp(*mf, sS_skij);
   long init_it = 0;
   if (!restart) {
     hamilt::set_fock(*mf, psp.get(), sHeff_skij, false);
   } else {
     init_it = chkpt::read_qpscf(mpi->node_comm, sHeff_skij, mu, mb_state.coqui_prefix);
   }
-
-  auto sMO_skia = make_shared_array<Array_view_4D_t>(*mpi, {mf->nspin(), mf->nkpts_ibz(), mf->nbnd(), mf->nbnd()});
-  auto sE_ska = make_shared_array<Array_view_3D_t>(*mpi, {mf->nspin(), mf->nkpts_ibz(), mf->nbnd()});
+  
+  auto sH0_skij = make_shared_array<Array_view_4D_t>(*mpi, {mf->nspin(), mf->nkpts_ibz(), mf->nbnd(), mf->nbnd()});
+  auto sS_skij = make_shared_array<Array_view_4D_t>(*mpi, {mf->nspin(), mf->nkpts_ibz(), mf->nbnd(), mf->nbnd()});
+  hamilt::set_H0(*mf, psp.get(), sH0_skij);
+  hamilt::set_ovlp(*mf, sS_skij);
 
   // Obtains MO coefficients and energies from the given mean-field object
   Timer.start("CANONICALIZATION");
@@ -332,18 +346,14 @@ double qp_scf_loop(MBState &mb_state, eri_t &mb_eri, const imag_axes_ft::IAFT& F
     }
     if (mb_solver.corr != nullptr) { // GW
       mb_solver.corr->iter() = it;
-      if constexpr (evscf_only) {
-        // add_evscf_vcorr() does the following two things:
-        // 1. return GW quasiparticle energies
-        // 2. update sHeff_skij as a diagonal matrix whose diagonals correspond to GW qp energies.
-        if (niter>1)
-          add_evscf_vcorr<false>(mb_state, sE_ska, sMO_skia, mu, mb_solver, mb_eri.corr_eri->get(), FT, qp_context);
-        else
-          add_evscf_vcorr<true>(mb_state, sE_ska, sMO_skia, mu, mb_solver, mb_eri.corr_eri->get(), FT, qp_context);
-        mpi->comm.barrier();
+      if (qp_params.qp_scf_mode == "evscf") {
+        // add_evscf_vcorr update two things in mb_state: 
+        // 1. QP energies
+        // 2. sHeff_skij with the updated QP energies while keeping sMO_skia the same.
+        add_evscf_vcorr(mb_state, mu, mb_solver, mb_eri.corr_eri->get(), FT, qp_params, qp_params.keep_scr_coulomb_fixed);
       } else {
-        // add_qpscf_vcorr only updates sHeff_skij. sE_ska and sMO_skia are fixed.
-        add_qpscf_vcorr(mb_state, sE_ska, sMO_skia, mu, mb_solver, mb_eri.corr_eri->get(), FT, qp_context);
+        // add_qpscf_vcorr only updates sHeff_skij. MO_skia and E_ska are updated later. 
+        add_qpscf_vcorr(mb_state, mu, mb_solver, mb_eri.corr_eri->get(), FT, qp_params);
       }
     }
     Timer.stop("MBPT_SOLVERS");
@@ -353,7 +363,7 @@ double qp_scf_loop(MBState &mb_state, eri_t &mb_eri, const imag_axes_ft::IAFT& F
     Timer.stop("ITERATIVE");
 
     Timer.start("CANONICALIZATION");
-    if constexpr (!evscf_only) {
+    if (qp_params.qp_scf_mode != "evscf") {
       // update MO_skia and E_ska
       update_MOs(sMO_skia, sE_ska, sHeff_skij, sS_skij);
     }
@@ -509,46 +519,15 @@ scf_loop(utils::mpi_context_t<mpi3::communicator> &comm, dca_dyson & scf, mf::MF
          std::string output, int niter, bool restart, double conv_tol, bool const_mu,
          std::string input_grp, int input_iter);*/
 
-#define EVSCF_LOOP_INST(HF, HARTREE, EXCHANGE, CORR) \
-template double                                      \
-qp_scf_loop<true>(MBState&,                          \
-                  mb_eri_t<HF, HARTREE, EXCHANGE, CORR>&,    \
-                  const imag_axes_ft::IAFT&,         \
-                  qp_context_t&, \
-                  solvers::mb_solver_t<solvers::gw_t>,       \
-                  iter_scf::iter_scf_t*, \
-                  int, bool, double);
-
-// All combinations of thc/chol for 4 eri slots
-EVSCF_LOOP_INST(thc_reader_t, thc_reader_t, thc_reader_t, thc_reader_t)
-EVSCF_LOOP_INST(thc_reader_t, thc_reader_t, thc_reader_t, chol_reader_t)
-EVSCF_LOOP_INST(thc_reader_t, thc_reader_t, chol_reader_t, thc_reader_t)
-EVSCF_LOOP_INST(thc_reader_t, thc_reader_t, chol_reader_t, chol_reader_t)
-EVSCF_LOOP_INST(thc_reader_t, chol_reader_t, thc_reader_t, thc_reader_t)
-EVSCF_LOOP_INST(thc_reader_t, chol_reader_t, thc_reader_t, chol_reader_t)
-EVSCF_LOOP_INST(thc_reader_t, chol_reader_t, chol_reader_t, thc_reader_t)
-EVSCF_LOOP_INST(thc_reader_t, chol_reader_t, chol_reader_t, chol_reader_t)
-EVSCF_LOOP_INST(chol_reader_t, thc_reader_t, thc_reader_t, thc_reader_t)
-EVSCF_LOOP_INST(chol_reader_t, thc_reader_t, thc_reader_t, chol_reader_t)
-EVSCF_LOOP_INST(chol_reader_t, thc_reader_t, chol_reader_t, thc_reader_t)
-EVSCF_LOOP_INST(chol_reader_t, thc_reader_t, chol_reader_t, chol_reader_t)
-EVSCF_LOOP_INST(chol_reader_t, chol_reader_t, thc_reader_t, thc_reader_t)
-EVSCF_LOOP_INST(chol_reader_t, chol_reader_t, thc_reader_t, chol_reader_t)
-EVSCF_LOOP_INST(chol_reader_t, chol_reader_t, chol_reader_t, thc_reader_t)
-EVSCF_LOOP_INST(chol_reader_t, chol_reader_t, chol_reader_t, chol_reader_t)
-
-#undef EVSCF_LOOP_INST
-
-
 #define QPSCF_LOOP_INST(HF, HARTREE, EXCHANGE, CORR) \
 template double                                      \
-qp_scf_loop<false>(MBState&,                         \
-                   mb_eri_t<HF, HARTREE, EXCHANGE, CORR>&,    \
-                   const imag_axes_ft::IAFT&,         \
-                   qp_context_t&, \
-                   solvers::mb_solver_t<solvers::gw_t>,       \
-                   iter_scf::iter_scf_t*, \
-                   int, bool, double);
+qp_scf_loop(MBState&,                         \
+            mb_eri_t<HF, HARTREE, EXCHANGE, CORR>&,    \
+            const imag_axes_ft::IAFT&,         \
+            qp_params_t&, \
+            solvers::mb_solver_t<solvers::gw_t>,       \
+            iter_scf::iter_scf_t*, \
+            int, bool, double);
 
 // All combinations of thc/chol for 4 eri slots
 QPSCF_LOOP_INST(thc_reader_t, thc_reader_t, thc_reader_t, thc_reader_t)

--- a/src/methods/SCF/scf_driver.hpp
+++ b/src/methods/SCF/scf_driver.hpp
@@ -32,23 +32,38 @@
 #include "numerics/iter_scf/iter_scf_t.hpp"
 
 #include "utilities/mpi_context.h"
-#include "methods/SCF/qp_context.h"
+#include "methods/SCF/qp_params_t.h"
 #include "methods/SCF/scf_common.hpp"
 #include "methods/SCF/mb_solver_t.h"
 #include "methods/mb_state/mb_state.hpp"
 
 namespace methods {
+/**
+ * Generic self-consistent loop for full-freuqency Green's function methods. 
+ * The template parameters allow for different types of self-energy solvers (e.g. HF, GW, GF2) 
+ * and different types of Coulomb Hamiltonian representations (e.g. THC, Cholesky).
+ */
 template<typename dyson_type, typename eri_t, typename corr_solver_t>
 auto scf_loop(MBState &mb_state, dyson_type &dyson, eri_t &mb_eri, const imag_axes_ft::IAFT& FT,
               solvers::mb_solver_t<corr_solver_t> mb_solver, iter_scf::iter_scf_t *iter_solver = nullptr,
               int niter = 1, bool restart = false, double conv_tol = 1e-9, bool const_mu = false,
               std::string input_grp = "scf", int input_iter = -1)
               -> std::tuple<double, double>;
-template<bool evscf_only, typename eri_t, typename corr_solver_t>
+
+/**
+ * Generic self-consistent loop for quasiparticle equations. 
+ * The template parameters allow for different types of self-energy solvers (e.g. HF, GW, GF2) 
+ * and different types of Coulomb Hamiltonian representations (e.g. THC, Cholesky).
+ */
+template<typename eri_t, typename corr_solver_t>
 double qp_scf_loop(MBState &mb_state, eri_t &mb_eri, const imag_axes_ft::IAFT& FT,
-                   qp_context_t &qp_context, solvers::mb_solver_t<corr_solver_t> mb_solver,
+                   qp_params_t &qp_params, solvers::mb_solver_t<corr_solver_t> mb_solver,
                    iter_scf::iter_scf_t *iter_solver = nullptr, int niter = 1,
                    bool restart = false, double conv_tol = 1e-8);
+
+/**
+ * RPA energy functional loop.
+ */
 template<typename eri_t, typename dyson_type>
 double rpa_loop(MBState &mb_state, dyson_type &dyson, eri_t &mb_eri, const imag_axes_ft::IAFT& FT,
                 solvers::mb_solver_t<solvers::gw_t> mb_solver);

--- a/src/methods/SCF/scf_driver.hpp
+++ b/src/methods/SCF/scf_driver.hpp
@@ -39,7 +39,7 @@
 
 namespace methods {
 /**
- * Generic self-consistent loop for full-freuqency Green's function methods. 
+ * Generic self-consistent loop for full-frequency Green's function methods. 
  * The template parameters allow for different types of self-energy solvers (e.g. HF, GW, GF2) 
  * and different types of Coulomb Hamiltonian representations (e.g. THC, Cholesky).
  */

--- a/src/methods/embedding/downfold_1e.cpp
+++ b/src/methods/embedding/downfold_1e.cpp
@@ -105,7 +105,7 @@ namespace methods {
   }
 
   void embed_t::downfolding(MBState &mb_state, ptree const& pt,
-                            qp_context_t *qp_context, std::string format_type) {
+                            qp_params_t *qp_params, std::string format_type) {
 
     std::string filename = mb_state.coqui_prefix + ".mbpt.h5";
     utils::check(std::filesystem::exists(filename),
@@ -117,9 +117,9 @@ namespace methods {
         pt, "dc_type", err+"dc_type. Valid types are \"hartree\", \"hf\", \"gw\", \"gw_dynamic_u\" and \"gw_mix_u\".");
     io::tolower(dc_type);
 
-    if (qp_context!=nullptr) {
+    if (qp_params!=nullptr) {
       utils::check(format_type == "default" or update_dc, "embed_t::downfolding: format_type!=default requires update_dc.");
-      downfold_mb_solution_qp_impl(mb_state, *qp_context, update_dc, dc_type,
+      downfold_mb_solution_qp_impl(mb_state, *qp_params, update_dc, dc_type,
                                    io::get_value_with_default<bool>(pt, "force_real", true),
                                    format_type);
     } else {
@@ -511,7 +511,7 @@ namespace methods {
     print_downfold_mb_timers();
   }
 
-  void embed_t::downfold_mb_solution_qp_impl(MBState &mb_state, qp_context_t &qp_context,
+  void embed_t::downfold_mb_solution_qp_impl(MBState &mb_state, qp_params_t &qp_params,
                                              bool update_dc, std::string dc_type,
                                              bool force_real, std::string format_type) {
     using math::shm::make_shared_array;
@@ -609,10 +609,10 @@ namespace methods {
       // b) compute qp energies; sbuff_tskij = Sigma_tskij, sbuff_skij = Vhf_skij
       if (sVhf_skij.node_comm()->root()) sVhf_skij.local() += dyson.H0();
       mpi->comm.barrier();
-      solve_qp_eqn(sE_ska, sSigma_tskij, sVhf_skij, sMO_skia, mu, *ft, qp_context);
+      solve_qp_eqn(sE_ska, sSigma_tskij, sVhf_skij, sMO_skia, mu, *ft, qp_params);
 
       // c) qp approximation for V_QPGW^{k}
-      sVcorr_skij = qp_approx(sSigma_tskij,  sMO_skia, sE_ska, mu, *ft, qp_context);
+      sVcorr_skij = qp_approx(sSigma_tskij,  sMO_skia, sE_ska, mu, *ft, qp_params);
       // this is not necessary but useful.
       double mu_qpgw = update_mu(mu, *_MF, sE_ska, ft->beta());
 
@@ -702,7 +702,7 @@ namespace methods {
     std::string dc_src_grp = (embed_iter!=-1)? "embed" : "scf";
     auto [Vhf_dc_sIab, Vcorr_dc_sIab, Sigma_dc_tsIab] = (update_dc)?
         double_counting_qp(mb_state.coqui_prefix, dc_type, dc_iter, dc_src_grp, weiss_b_iter, *ft,
-                           mu, sMO_skia, sE_ska, qp_context, force_real, format_type) :
+                           mu, sMO_skia, sE_ska, qp_params, force_real, format_type) :
         read_double_counting_qp(filename, weiss_f_iter, *ft);
     nda::array<ComplexType, 5> Sigma_dc_wsIab(ft->nw_f(), _MF->nspin(), nImps, nImpOrbs, nImpOrbs);
     ft->tau_to_w(Sigma_dc_tsIab, Sigma_dc_wsIab, imag_axes_ft::fermion);
@@ -1244,7 +1244,7 @@ namespace methods {
                                 long weiss_b_iter, imag_axes_ft::IAFT &ft,
                                 double mu,
                                 sArray_t<Array_view_4D_t> &sMO_skia, sArray_t<Array_view_3D_t> &sE_ska,
-                                qp_context_t &qp_context, bool force_real, std::string format_type)
+                                qp_params_t &qp_params, bool force_real, std::string format_type)
   -> std::tuple<nda::array<ComplexType, 4>, nda::array<ComplexType, 4>, nda::array<ComplexType, 5>> {
     app_log(2, "Evaluating double counting self-energy with Gloc coming from "
                "\"{}/iter{}\"", dc_src_grp, dc_iter);
@@ -1331,7 +1331,7 @@ namespace methods {
             *_context, {ft.nt_f(), _MF->nspin(), _MF->nkpts_ibz(), _MF->nbnd(), _MF->nbnd()});
         Sigma_dc_tsIab = gw_double_counting_dmft<false>(_context->comm, Gloc_tsIab, Uw0_abcd, ft);
         _proj.value().upfold(sSigma_dc_tskij, Sigma_dc_tsIab); // upfold to the primary basis
-        auto sVcorr_skij = qp_approx(sSigma_dc_tskij,  sMO_skia, sE_ska, mu, ft, qp_context); // static approximation
+        auto sVcorr_skij = qp_approx(sSigma_dc_tskij,  sMO_skia, sE_ska, mu, ft, qp_params); // static approximation
         // downfolding
         Vcorr_dc_sIab = (force_real)?
             _proj.value().downfold_loc<true>(sVcorr_skij, "Vcorr_dc_loc") :
@@ -1354,7 +1354,7 @@ namespace methods {
         nda::h5_read(weiss_b_grp, "iter" + std::to_string(weiss_b_iter) + "/Uloc_wabcd", U_wabcd);
         Sigma_dc_tsIab = gw_double_counting_dmft<false>(_context->comm, Gloc_tsIab, V_abcd, U_wabcd, ft);
         _proj.value().upfold(sSigma_dc_tskij, Sigma_dc_tsIab); // upfold to the primary basis
-        auto sVcorr_skij = qp_approx(sSigma_dc_tskij,  sMO_skia, sE_ska, mu, ft, qp_context); // static approximation
+        auto sVcorr_skij = qp_approx(sSigma_dc_tskij,  sMO_skia, sE_ska, mu, ft, qp_params); // static approximation
         // downfolding
         Vcorr_dc_sIab = (force_real)?
             _proj.value().downfold_loc<true>(sVcorr_skij, "Vcorr_dc_loc") :
@@ -1390,7 +1390,7 @@ namespace methods {
           auto sSigma_dc_tskij = math::shm::make_shared_array<Array_view_5D_t>(
                 *_context, {ft.nt_f(), _MF->nspin(), _MF->nkpts_ibz(), _MF->nbnd(), _MF->nbnd()});
           _proj.value().upfold(sSigma_dc_tskij, Sigma_dc_tsIab); // upfold to the primary basis
-          auto sVcorr_skij = qp_approx(sSigma_dc_tskij,  sMO_skia, sE_ska, mu, ft, qp_context); 
+          auto sVcorr_skij = qp_approx(sSigma_dc_tskij,  sMO_skia, sE_ska, mu, ft, qp_params); 
           // downfolding
           Vcorr_dc_sIab = (force_real)?
                 _proj.value().downfold_loc<true>(sVcorr_skij, "Vcorr_dc_loc") :
@@ -1412,7 +1412,7 @@ namespace methods {
                                    long weiss_b_iter, imag_axes_ft::IAFT &ft,
                                    double mu,
                                    sArray_t<Array_view_4D_t> &sMO_skia, sArray_t<Array_view_3D_t> &sE_ska,
-                                   qp_context_t &qp_context, bool force_real, std::string format_type)
+                                   qp_params_t &qp_params, bool force_real, std::string format_type)
   -> std::tuple<nda::array<ComplexType, 4>, nda::array<ComplexType, 4>, nda::array<ComplexType, 5>> {
     h5::file file(prefix+".mbpt.h5", 'r');
     auto grp = h5::group(file);
@@ -1420,12 +1420,12 @@ namespace methods {
                  "Invalid format_type: {}",format_type);
     if(format_type == "default") {
       return double_counting_qp(grp, grp, prefix, dc_type, dc_iter, dc_src_grp,
-                         weiss_b_iter, ft, mu, sMO_skia, sE_ska, qp_context, force_real, format_type);
+                         weiss_b_iter, ft, mu, sMO_skia, sE_ska, qp_params, force_real, format_type);
     } else {
       h5::file fileV(prefix+".model.h5", 'r');
       auto grpV = h5::group(fileV);
       return double_counting_qp(grp, grpV, prefix, dc_type, dc_iter, dc_src_grp,
-                         weiss_b_iter, ft, mu, sMO_skia, sE_ska, qp_context, force_real, format_type);
+                         weiss_b_iter, ft, mu, sMO_skia, sE_ska, qp_params, force_real, format_type);
     }
   }
 

--- a/src/methods/embedding/embed_t.h
+++ b/src/methods/embedding/embed_t.h
@@ -97,11 +97,11 @@ namespace methods {
      *                                (only used when scf_type == many_body)
      * @param dc_type       - [INPUT] dmft: phi-functional; edmft: psi-functional
      *                                (right now, it is only used when scf_type == quasiparticle)
-     * @param qp_context    - [INPUT] quasiparticle approximation parameters
+     * @param qp_params    - [INPUT] quasiparticle approximation parameters
      * @param format_type   - [OPTION] Type of output: "default", "interaction_static"
      */
     void downfolding(MBState &mb_state, ptree const& pt,
-                     qp_context_t *qp_context = nullptr, std::string format_type="default");
+                     qp_params_t *qp_params = nullptr, std::string format_type="default");
 
     template<THC_ERI thc_t>
     void hf_downfolding(std::string outdir, std::string prefix,
@@ -190,7 +190,7 @@ namespace methods {
      * @param filename - [INPUT] checkpoint h5 file
      * @param dc_type  - [INPUT] double counting type
      */
-    void downfold_mb_solution_qp_impl(MBState &mb_state, qp_context_t &qp_context,
+    void downfold_mb_solution_qp_impl(MBState &mb_state, qp_params_t &qp_params,
                                       bool update_dc, std::string dc_type,
                                       bool force_real, std::string format_type = "default");
     /**
@@ -225,14 +225,14 @@ namespace methods {
                             std::string dc_type, long dc_iter, std::string dc_src_grp,
                             long weiss_b_iter, imag_axes_ft::IAFT &ft,
                             double mu, sArray_t<Array_view_4D_t> &sMO_skia, sArray_t<Array_view_3D_t> &sE_ska,
-                            qp_context_t &qp_context, bool force_real, std::string format_type)
+                            qp_params_t &qp_params, bool force_real, std::string format_type)
     -> std::tuple<nda::array<ComplexType, 4>, nda::array<ComplexType, 4>, nda::array<ComplexType, 5>>;
 
     auto double_counting_qp(std::string prefix,
                             std::string dc_type, long dc_iter, std::string dc_src_grp,
                             long weiss_b_iter, imag_axes_ft::IAFT &ft,
                             double mu, sArray_t<Array_view_4D_t> &sMO_skia, sArray_t<Array_view_3D_t> &sE_ska,
-                            qp_context_t &qp_context, bool force_real, std::string format_type)
+                            qp_params_t &qp_params, bool force_real, std::string format_type)
     -> std::tuple<nda::array<ComplexType, 4>, nda::array<ComplexType, 4>, nda::array<ComplexType, 5>>;
 
     /**

--- a/src/methods/embedding/tests/test_embed.cpp
+++ b/src/methods/embedding/tests/test_embed.cpp
@@ -189,13 +189,13 @@ TEST_CASE("downfold_1e_mb_qp", "[methods][embed][df_1e]") {
                                                       solvers::mb_solver_t(&hf,&gw,&scr_eri),
                                                       &iter_sol, 1, true, 1e-9, false);
 
-      qp_context_t qp_context("sc", "pade", 18, 1e-8, 1e-8, "qp_energy");
+      qp_params_t qp_params("sc", "pade", 18, 1e-8, 1e-8, "qpscf", false, "qp_energy");
       embed_t embed_1e(*mf, wannier_file, true);
       ptree pt_1e;
       pt_1e.put("update_dc", true);
       pt_1e.put("force_real", true);
       pt_1e.put("dc_type", dc_type);
-      embed_1e.downfolding(mb_state, pt_1e, &qp_context);
+      embed_1e.downfolding(mb_state, pt_1e, &qp_params);
 
       // check downfolded Hamiltonian
       std::string fname = coqui_prefix+".mbpt.h5";
@@ -755,13 +755,13 @@ TEST_CASE("downfold_1e_mb_qp", "[methods][embed][df_1e]") {
                                                         solvers::mb_solver_t(&hf,&gw,&scr_eri),
                                                         &iter_sol, 1, true, 1e-9, false);
 
-        qp_context_t qp_context("sc", "pade", 18, 1e-8, 1e-8, "qp_energy");
+        qp_params_t qp_params("sc", "pade", 18, 1e-8, 1e-8, "qpscf", false, "qp_energy");
         embed_t embed(*mf, wannier_file, true);
         ptree pt_1e;
         pt_1e.put("update_dc", true);
         pt_1e.put("dc_type", "gw");
         pt_1e.put("force_real", false);
-        embed.downfolding(mb_state, pt_1e, &qp_context);
+        embed.downfolding(mb_state, pt_1e, &qp_params);
         mpi->comm.barrier();
       }
 
@@ -823,14 +823,14 @@ TEST_CASE("downfold_1e_mb_qp", "[methods][embed][df_1e]") {
                                                         &iter_sol, 1, true, 1e-9, false);
         mpi->comm.barrier();
 
-        qp_context_t qp_context("sc", "pade", 18, 1e-8, 1e-8, "qp_energy");
+        qp_params_t qp_params("sc", "pade", 18, 1e-8, 1e-8, "qpscf", false, "qp_energy");
         mpi->comm.barrier();
         embed_t embed(*mf, wannier_file, true);
         ptree pt_1e;
         pt_1e.put("update_dc", true);
         pt_1e.put("dc_type", "gw");
         pt_1e.put("force_real", false);
-        embed.downfolding(mb_state, pt_1e, &qp_context, "model_static");
+        embed.downfolding(mb_state, pt_1e, &qp_params, "model_static");
         mpi->comm.barrier();
       }
 

--- a/src/methods/mb_state/mb_state.hpp
+++ b/src/methods/mb_state/mb_state.hpp
@@ -116,7 +116,7 @@ public:
   // Head (G=G'=0) of the inverse dielectric function in the long wavelength limit (q->0 and w->0)
   std::optional<nda::array<ComplexType, 1> > eps_inv_head;
 
-  /** Quansi-paritcle SCF specific */
+  /** Quasiparticle SCF specific */
   // Effective QP Hamiltonian in QP-SCF
   std::optional<sArray_t<nda::array_view<ComplexType, 4> > > sHeff_skij;
   // QP coefficients
@@ -125,14 +125,14 @@ public:
   std::optional<sArray_t<nda::array_view<ComplexType, 3> > > sE_ska;
 
   
-  /** local quantities in MLWF basisfor quantum embedding */
+  /** local quantities in MLWF basis for quantum embedding */
   // Projector from Bloch states to MLWFs. 
   std::optional<projector_boson_t> proj_boson;
   // Dynamic part of the impurity self-energy
   std::optional<nda::array<ComplexType, 5> > Sigma_imp_wsIab;
   // Static part of the impurity self-energy
   std::optional<nda::array<ComplexType, 4> > Vhf_imp_sIab;
-  // Dyanmic part of the double-counting self-energy
+  // Dynamic part of the double-counting self-energy
   std::optional<nda::array<ComplexType, 5> > Sigma_dc_wsIab;
   // Static part of the double-counting self-energy
   std::optional<nda::array<ComplexType, 4> > Vhf_dc_sIab;

--- a/src/methods/mb_state/mb_state.hpp
+++ b/src/methods/mb_state/mb_state.hpp
@@ -94,29 +94,55 @@ public:
 
   // checkpoint file info
   std::string coqui_prefix = "coqui";
-  long mbpt_iter = -1; // iteration number of the many-body solution
+  long mbpt_iter = -1;  // iteration number of the many-body solution
   long df_1e_iter = -1; // iteration number of the downfolded 1e Hamiltonian
   long df_2e_iter = -1; // iteration number of the downfolded 2e Hamiltonian
   long embed_iter = -1; // iteration number of the embedding solution
 
   /** all components of a many-body state are optional **/
-  // lattice quantities
+  /** lattice quantities **/
+  // Green's function
   std::optional<sArray_t<nda::array_view<ComplexType, 5> > > sG_tskij;
+  // Density matrix
   std::optional<sArray_t<nda::array_view<ComplexType, 4> > > sDm_skij;
+  // Dynamic part of the self-energy
   std::optional<sArray_t<nda::array_view<ComplexType, 5> > > sSigma_tskij;
+  // Static part of the self-energy
   std::optional<sArray_t<nda::array_view<ComplexType, 4> > > sF_skij;
+  // Dynamically screened interaction w/o bare term
   std::optional<dArray_t<nda::array<ComplexType, 4> > > dW_qtPQ;
-  std::optional<nda::array<ComplexType, 1> > eps_inv_head;
+  // Flag to determine screening recipe to calculate the dynamically screened interaction. 
   std::string screen_type = "";
-  // local quantities for quantum embedding
-  std::optional<projector_boson_t> proj_boson; // Since projector is always used with a many-body state, we let MBState own it
+  // Head (G=G'=0) of the inverse dielectric function in the long wavelength limit (q->0 and w->0)
+  std::optional<nda::array<ComplexType, 1> > eps_inv_head;
+
+  /** Quansi-paritcle SCF specific */
+  // Effective QP Hamiltonian in QP-SCF
+  std::optional<sArray_t<nda::array_view<ComplexType, 4> > > sHeff_skij;
+  // QP coefficients
+  std::optional<sArray_t<nda::array_view<ComplexType, 4> > > sMO_skia;
+  // QP energies
+  std::optional<sArray_t<nda::array_view<ComplexType, 3> > > sE_ska;
+
+  
+  /** local quantities in MLWF basisfor quantum embedding */
+  // Projector from Bloch states to MLWFs. 
+  std::optional<projector_boson_t> proj_boson;
+  // Dynamic part of the impurity self-energy
   std::optional<nda::array<ComplexType, 5> > Sigma_imp_wsIab;
+  // Static part of the impurity self-energy
   std::optional<nda::array<ComplexType, 4> > Vhf_imp_sIab;
-  std::optional<nda::array<ComplexType, 4> > Vcorr_dc_sIab;
+  // Dyanmic part of the double-counting self-energy
   std::optional<nda::array<ComplexType, 5> > Sigma_dc_wsIab;
+  // Static part of the double-counting self-energy
   std::optional<nda::array<ComplexType, 4> > Vhf_dc_sIab;
+  // Impurity polarizability
   std::optional<sArray_t<nda::array_view<ComplexType, 5> > > sPi_imp_wabcd;
+  // Double-counting polarizability
   std::optional<sArray_t<nda::array_view<ComplexType, 5> > > sPi_dc_wabcd;
+
+  // Quasiparticle approx. to the dynamic part of the double-counting self-energy
+  std::optional<nda::array<ComplexType, 4> > Vcorr_dc_sIab;
 
 };
 

--- a/src/numerics/ac/CMakeLists.txt
+++ b/src/numerics/ac/CMakeLists.txt
@@ -5,3 +5,7 @@ add_library(ac_lib INTERFACE)
 target_link_libraries(ac_lib INTERFACE utils numerics)
 install(TARGETS ac_lib
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+if (BUILD_UNIT_TESTS)
+        add_subdirectory(pade/tests)
+endif()

--- a/src/numerics/ac/pade/pade_driver.hpp
+++ b/src/numerics/ac/pade/pade_driver.hpp
@@ -32,7 +32,7 @@
 namespace analyt_cont {
   struct pade_driver {
   public:
-    pade_driver() = default;
+    explicit pade_driver(pade_impl_e impl = pade_impl_e::original): _pade_kernel(impl) {}
 
     pade_driver(const pade_driver& other) = default;
     pade_driver(pade_driver&& other) = default;
@@ -53,9 +53,11 @@ namespace analyt_cont {
 
       long niw_pos = (is_iw_pos_only)? niw : niw/2;
       if (Nfit == -1) Nfit = niw_pos;
-      utils::check(Nfit <= niw_pos,
-                   "pade_driver::init: Nfit ({}) > number of positive imaginary frequency points ({})",
-                   Nfit, niw_pos);
+      if (Nfit > niw_pos) {
+        app_log(4, "[WARNING]: Pade: Nfit ({}) is larger than the number of positive imaginary frequency points ({}). "
+                   "Setting Nfit to {}.\n", Nfit, niw_pos, niw_pos);
+        Nfit = niw_pos;
+      }
 
       // determine the imaginary frequencies for fitting
       auto Aiw_2D = nda::reshape(A_iw, std::array<long, 2>{niw, dim1});
@@ -81,7 +83,8 @@ namespace analyt_cont {
         A_fit(nda::ellipsis{}) = Aiw_2D(fit_iw_rng, nda::range::all);
       }
 
-      app_log(2, "Solving {}-point Pade interpolation.\n", Nfit);
+      app_log(2, "Solving {}-point Pade interpolation using {} implementation.\n",
+              Nfit, (_pade_kernel.implementation() == pade_impl_e::updated)? "updated" : "original");
       _pade_kernel.init(iw_fit, A_fit);
     }
 

--- a/src/numerics/ac/pade/pade_t.hpp
+++ b/src/numerics/ac/pade/pade_t.hpp
@@ -29,6 +29,11 @@
 #include <boost/multiprecision/cpp_dec_float.hpp>
 
 namespace analyt_cont {
+  enum class pade_impl_e {
+    original,
+    updated
+  };
+
   template<int prec=100>
   class pade_t {
   public:
@@ -38,7 +43,7 @@ namespace analyt_cont {
     using mp_complex = std::complex<mp_float>;
 
   public:
-    pade_t() = default;
+    explicit pade_t(pade_impl_e impl = pade_impl_e::original): _impl(impl) {}
     pade_t(pade_t const&) = default;
     pade_t(pade_t &&) = default;
     pade_t& operator=(pade_t const& other) = default;
@@ -55,9 +60,11 @@ namespace analyt_cont {
     void init(iw_mesh_t &&iw_mesh, Array_iw_t &&A_iw) {
       _Nfit = A_iw.shape(0);
       _dim1 = A_iw.shape(1);
+      utils::check(_Nfit >= 1, "pade_t.hpp::init: Nfit ({}) must be at least 1", _Nfit);
 
       _iw_fit = nda::array<mp_complex, 1>(_Nfit);
       _coeffs = nda::array<mp_complex, 2>(_dim1, _Nfit);
+      _orders = nda::array<long, 1>(_dim1);
       nda::array<mp_complex, 1> Ad_iw(_Nfit);
 
       for (long w=0; w<_Nfit; ++w)
@@ -67,7 +74,8 @@ namespace analyt_cont {
         for (long w=0; w<_Nfit; ++w)
           Ad_iw(w) = mp_complex(mp_float(A_iw(w, d).real()),
                                 mp_float(A_iw(w, d).imag()));
-        fit(Ad_iw, _iw_fit, _coeffs(d,nda::range::all));
+        // the effective order of the pade approx. can be smaller than Nfit due to truncation. 
+        _orders(d) = fit(Ad_iw, _iw_fit, _coeffs(d,nda::range::all));
       }
     }
 
@@ -77,17 +85,8 @@ namespace analyt_cont {
       nda::array<ComplexType, 2> A_wI(Nw, _dim1);
       for (long d1 = 0; d1 < _dim1; ++d1) {
         for (long w = 0; w < Nw; ++w) {
-          // a(Nfit) * (w - z_fit(Nfit-1) )
           mp_complex w_hpc( mp_float(w_mesh(w).real()), mp_float(w_mesh(w).imag()) );
-          // Xw = _coeffs(d1,_Nfit-1) * ( w_hpc - _iw_fit(_Nfit-2) );
-          mp_complex Xw = _mul_sub(_coeffs(d1,_Nfit-1), w_hpc, _iw_fit(_Nfit-2));
-          for (long f = 1; f < _Nfit-1; ++f) {
-            long idx = _Nfit - f - 1;
-            // Xw = _coeffs(d1,idx) * ( w_hpc - _iw_fit(idx-1) ) / ( (mp_complex)1.0 + Xw);
-            Xw = _mul_sub_div_add(_coeffs(d1,idx), w_hpc, _iw_fit(idx-1), Xw);
-          }
-          // Xw = _coeffs(d1,0) / ( (mp_complex)1.0 + Xw);
-          Xw = _div_add(_coeffs(d1,0), Xw);
+          mp_complex Xw = _evaluate_impl(w_hpc, d1);
           A_wI(w, d1) = ComplexType(Xw.real().template convert_to<RealType>(),
                                     Xw.imag().template convert_to<RealType>());
         }
@@ -101,19 +100,7 @@ namespace analyt_cont {
       nda::array<ComplexType, 1> A_w(Nw);
       for (long w = 0; w < Nw; ++w) {
         mp_complex w_hpc( mp_float(w_mesh(w).real()), mp_float(w_mesh(w).imag()) );
-
-        // Xw = _coeffs(d1,_Nfit-1) * ( w_hpc - _iw_fit(_Nfit-2) );
-        mp_complex Xw = _mul_sub(_coeffs(d1,_Nfit-1), w_hpc, _iw_fit(_Nfit-2));
-
-        for (long f = 1; f < _Nfit-1; ++f) {
-          long idx = _Nfit - f - 1;
-
-          // Xw = _coeffs(d1,idx) * ( w_hpc - _iw_fit(idx-1) ) / ( (mp_complex)1.0 + Xw);
-          Xw = _mul_sub_div_add(_coeffs(d1,idx), w_hpc, _iw_fit(idx-1), Xw);
-        }
-
-        // Xw = _coeffs(d1,0) / ( (mp_complex)1.0 + Xw);
-        Xw = _div_add(_coeffs(d1,0), Xw);
+        mp_complex Xw = _evaluate_impl(w_hpc, d1);
 
         A_w(w) = ComplexType(Xw.real().template convert_to<RealType>(),
                              Xw.imag().template convert_to<RealType>());
@@ -123,20 +110,7 @@ namespace analyt_cont {
 
     ComplexType evaluate(ComplexType w, long d1) {
       mp_complex w_hpc( mp_float(w.real()), mp_float(w.imag()) );
-
-      // Xw = _coeffs(d1,_Nfit-1) * ( w_hpc - _iw_fit(_Nfit-2) );
-      mp_complex Xw = _mul_sub(_coeffs(d1,_Nfit-1), w_hpc, _iw_fit(_Nfit-2));
-
-      for (long f = 1; f < _Nfit-1; ++f) {
-        long idx = _Nfit-f-1;
-
-        // Xw = _coeffs(d1,idx) * ( w_hpc - _iw_fit(idx-1) ) / ( (mp_complex)1.0 + Xw);
-        Xw = _mul_sub_div_add(_coeffs(d1,idx), w_hpc, _iw_fit(idx-1), Xw);
-
-      }
-
-      // Xw = _coeffs(d1,0) / ( (mp_complex)1.0 + Xw);
-      Xw = _div_add(_coeffs(d1,0), Xw);
+      mp_complex Xw = _evaluate_impl(w_hpc, d1);
 
       return ComplexType(Xw.real().template convert_to<RealType>(),
                          Xw.imag().template convert_to<RealType>());
@@ -145,7 +119,10 @@ namespace analyt_cont {
     void reset() {
       _iw_fit = nda::array<mp_complex, 1>();
       _coeffs = nda::array<mp_complex, 2>();
+      _orders = nda::array<long, 1>();
     }
+
+    pade_impl_e implementation() const { return _impl; }
 
   private:
     /**
@@ -174,24 +151,69 @@ namespace analyt_cont {
     }
 
     template<nda::ArrayOfRank<1> Az_t, nda::ArrayOfRank<1> w_mesh_t, nda::ArrayOfRank<1> coeff_t>
-    void fit(Az_t &&Az, w_mesh_t &&z_fit, coeff_t &&coeffs) {
+    long fit(Az_t &&Az, w_mesh_t &&z_fit, coeff_t &&coeffs) {
       // g(i, j) = g_i(z_j)
       nda::array<mp_complex, 2> g(_Nfit, _Nfit);
+      g() = mp_complex{mp_float(0), mp_float(0)};
       g(0, nda::range::all) = Az();
 
+      long order = 1;
+
       for (long i=1; i<_Nfit; ++i) {
+        if (_impl == pade_impl_e::updated && _norm(g(i-1, i-1)) < _tiny_pivot_tol()) break;
+
         for (long j=i; j<_Nfit; ++j) {
           // g(i, j) = ( g(i-1,i-1) - g(i-1,j) ) / ( (z_fit(j) - z_fit(i-1)) * g(i-1, j) );
           g(i, j) = _sub_div_mul(g(i-1,i-1), g(i-1,j), z_fit(j), z_fit(i-1), g(i-1,j));
         }
+        order = i + 1;
       }
       coeffs() = nda::diagonal(g);
+      return order;
+    }
+
+    mp_complex _evaluate_impl(const mp_complex& w, long d1) const {
+      return (_impl == pade_impl_e::updated)? _evaluate_updated(w, d1) : _evaluate_original(w, d1);
+    }
+
+    mp_complex _evaluate_original(const mp_complex& w, long d1) const {
+      long order = _orders(d1);
+      if (order <= 0) return mp_complex{mp_float(0), mp_float(0)};
+      if (order == 1) return _coeffs(d1, 0);
+
+      mp_complex Xw = _mul_sub(_coeffs(d1, order-1), w, _iw_fit(order-2));
+      for (long f = 1; f < order-1; ++f) {
+        long idx = order - f - 1;
+        Xw = _mul_sub_div_add(_coeffs(d1, idx), w, _iw_fit(idx-1), Xw);
+      }
+      return _div_add(_coeffs(d1, 0), Xw);
+    }
+
+    mp_complex _evaluate_updated(const mp_complex& w, long d1) const {
+      long order = _orders(d1);
+      if (order <= 0) return mp_complex{mp_float(0), mp_float(0)};
+
+      mp_complex A1{mp_float(0), mp_float(0)};
+      mp_complex A2 = _coeffs(d1, 0);
+      mp_complex B1{mp_float(1), mp_float(0)};
+
+      for (long i = 0; i < order - 1; ++i) {
+        mp_complex scaled = _mul_sub(_coeffs(d1, i+1), w, _iw_fit(i));
+        mp_complex Anew = _add(A2, _mul(scaled, A1));
+        mp_complex Bnew = _add(mp_complex{mp_float(1), mp_float(0)}, _mul(scaled, B1));
+        mp_complex inv_Bnew = _inverse(Bnew, "pade_t.hpp::_evaluate_new");
+        A1 = _mul(A2, inv_Bnew);
+        A2 = _mul(Anew, inv_Bnew);
+        B1 = inv_Bnew;
+      }
+
+      return A2;
     }
 
     // helper functions to avoid std::complex<mp_float> arithmetics directly
     // Sadly, boost multiprecision number type is not fully compatible with std::complex<...> arithmetics
     // A * (B - C)
-    inline mp_complex _mul_sub(const mp_complex& A, const mp_complex& B, const mp_complex& C) {
+    inline mp_complex _mul_sub(const mp_complex& A, const mp_complex& B, const mp_complex& C) const {
       mp_float br = B.real() - C.real();
       mp_float bi = B.imag() - C.imag();
       mp_float ar = A.real();
@@ -202,8 +224,40 @@ namespace analyt_cont {
           ar * bi + ai * br
       };
     }
+
+    inline mp_complex _mul(const mp_complex& A, const mp_complex& B) const {
+      mp_float ar = A.real();
+      mp_float ai = A.imag();
+      mp_float br = B.real();
+      mp_float bi = B.imag();
+
+      return mp_complex{
+          ar * br - ai * bi,
+          ar * bi + ai * br
+      };
+    }
+
+    inline mp_complex _add(const mp_complex& A, const mp_complex& B) const {
+      return mp_complex{A.real() + B.real(), A.imag() + B.imag()};
+    }
+
+    inline mp_float _norm(const mp_complex& A) const {
+      return A.real() * A.real() + A.imag() * A.imag();
+    }
+
+    inline mp_complex _inverse(const mp_complex& A, const char* func_name) const {
+      mp_float ar = A.real();
+      mp_float ai = A.imag();
+      mp_float denom = ar * ar + ai * ai;
+      utils::check(denom != mp_float(0), "{}: division by zero in normalized Pad\u00e9 recurrence", func_name);
+      return mp_complex{ar / denom, -ai / denom};
+    }
+
+    static mp_float _tiny_pivot_tol() {
+      return mp_float("1e-20");
+    }
     // A * (B - C) / (1 + D)
-    inline mp_complex _mul_sub_div_add(const mp_complex& A, const mp_complex& B, const mp_complex& C, const mp_complex& D) {
+    inline mp_complex _mul_sub_div_add(const mp_complex& A, const mp_complex& B, const mp_complex& C, const mp_complex& D) const {
       // Numerator: A * (B - C)
       mp_float br = B.real() - C.real();
       mp_float bi = B.imag() - C.imag();
@@ -224,7 +278,7 @@ namespace analyt_cont {
       };
     }
     // A / (1 + B)
-    inline mp_complex _div_add(const mp_complex& A, const mp_complex& B) {
+    inline mp_complex _div_add(const mp_complex& A, const mp_complex& B) const {
       // Denominator: 1 + B
       mp_float br = mp_float(1) + B.real();
       mp_float bi = B.imag();
@@ -239,11 +293,12 @@ namespace analyt_cont {
       };
     }
 
-    mp_complex _sub_div_mul(const mp_complex& A,
-                           const mp_complex& B,
-                           const mp_complex& C,
-                           const mp_complex& D,
-                           const mp_complex& E) {
+    mp_complex _sub_div_mul(
+      const mp_complex& A,
+      const mp_complex& B,
+      const mp_complex& C,
+      const mp_complex& D,
+      const mp_complex& E) const {
       // U = A - B
       mp_float ur = A.real() - B.real();
       mp_float ui = A.imag() - B.imag();
@@ -271,10 +326,12 @@ namespace analyt_cont {
     }
 
   private:
+    pade_impl_e _impl = pade_impl_e::original;
     long _dim1 = 0;
     long _Nfit = 0;
     nda::array<mp_complex, 1> _iw_fit;
     nda::array<mp_complex, 2> _coeffs;
+    nda::array<long, 1> _orders;
   };
 } // analyt_cont
 

--- a/src/numerics/ac/pade/tests/CMakeLists.txt
+++ b/src/numerics/ac/pade/tests/CMakeLists.txt
@@ -1,0 +1,25 @@
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_UNIT_TEST_DIR})
+
+set(TEST_ID ac_pade)
+
+set(TEST_SRCS
+  test_pade.cpp
+)
+
+if(USE_DEVICE_COMPILER)
+if(ENABLE_CUDA)
+  foreach(X ${TEST_SRCS})
+    set_source_files_properties(${X} PROPERTIES LANGUAGE CUDA)
+  endforeach()
+elseif(ENABLE_HIP)
+  foreach(X ${TEST_SRCS})
+    set_source_files_properties(${X} PROPERTIES LANGUAGE HIP)
+  endforeach()
+endif()
+endif()
+
+add_executable(test_${TEST_ID} ${TEST_SRCS})
+target_link_libraries(test_${TEST_ID} PRIVATE catch_main utils numerics ac_lib)
+
+add_unit_test(test_${TEST_ID} "${PROJECT_UNIT_TEST_DIR}/test_${TEST_ID}")
+set_tests_properties(test_${TEST_ID} PROPERTIES WORKING_DIRECTORY ${PROJECT_UNIT_TEST_DIR})

--- a/src/numerics/ac/pade/tests/test_pade.cpp
+++ b/src/numerics/ac/pade/tests/test_pade.cpp
@@ -1,0 +1,160 @@
+/**
+ * ==========================================================================
+ * CoQuí: Correlated Quantum ínterface
+ *
+ * Copyright (c) 2022-2025 Simons Foundation & The CoQuí developer team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ==========================================================================
+ */
+
+#include "catch2/catch.hpp"
+
+#include "configuration.hpp"
+#include "nda/nda.hpp"
+
+#include "numerics/ac/pade/pade_driver.hpp"
+
+#include <cmath>
+#include <iostream>
+#include <random>
+
+namespace bdft_tests {
+
+  namespace {
+    inline ComplexType g_model(ComplexType z) {
+      return ComplexType{1.0, 0.0} / (z - ComplexType{0.7, 0.0})
+           + ComplexType{0.5, 0.0} / (z + ComplexType{1.6, 0.0});
+    }
+
+    auto make_iw_mesh_pos(double beta, long n_iw) {
+      nda::array<ComplexType, 1> iw(n_iw);
+      for (long n = 0; n < n_iw; ++n) {
+        iw(n) = ComplexType{0.0, (2.0 * n + 1.0) * M_PI / beta};
+      }
+      return iw;
+    }
+
+    auto make_w_mesh(double w_min, double w_max, long n_w, double eta) {
+      nda::array<ComplexType, 1> w_mesh(n_w);
+      for (long i = 0; i < n_w; ++i) {
+        double wr = w_min + static_cast<double>(i) * (w_max - w_min) / static_cast<double>(n_w - 1);
+        w_mesh(i) = ComplexType{wr, eta};
+      }
+      return w_mesh;
+    }
+
+    auto run_pade(analyt_cont::pade_impl_e impl,
+                  nda::array<ComplexType, 1> const &iw_mesh,
+                  nda::array<ComplexType, 2> const &A_iw,
+                  nda::array<ComplexType, 1> const &w_mesh,
+                  int Nfit) {
+      analyt_cont::pade_driver driver(impl);
+      driver.init(iw_mesh, A_iw, Nfit, true);
+
+      nda::array<ComplexType, 2> A_w(w_mesh.shape(0), 1);
+      driver.evaluate(w_mesh, A_w);
+      return A_w;
+    }
+
+    double mean_abs_error(nda::array<ComplexType, 2> const &A_w,
+                          nda::array<ComplexType, 1> const &w_mesh) {
+      double err = 0.0;
+      for (long i = 0; i < w_mesh.shape(0); ++i) {
+        err += std::abs(A_w(i, 0) - g_model(w_mesh(i)));
+      }
+      return err / static_cast<double>(w_mesh.shape(0));
+    }
+
+    bool all_finite(nda::array<ComplexType, 2> const &A_w) {
+      for (long i = 0; i < A_w.shape(0); ++i) {
+        for (long j = 0; j < A_w.shape(1); ++j) {
+          if (!std::isfinite(A_w(i, j).real()) || !std::isfinite(A_w(i, j).imag())) return false;
+        }
+      }
+      return true;
+    }
+  } // namespace
+
+  TEST_CASE("pade_original_vs_updated_synthetic", "[ac][pade]") {
+    const double beta = 200.0;
+    const long n_iw = 48;
+    const long n_w = 241;
+
+    auto iw_mesh = make_iw_mesh_pos(beta, n_iw);
+    auto w_mesh = make_w_mesh(-3.0, 3.0, n_w, 0.05);
+
+    nda::array<ComplexType, 2> A_iw(n_iw, 1);
+    for (long n = 0; n < n_iw; ++n) A_iw(n, 0) = g_model(iw_mesh(n));
+
+    auto A_w_original = run_pade(analyt_cont::pade_impl_e::original, iw_mesh, A_iw, w_mesh, 32);
+    auto A_w_updated = run_pade(analyt_cont::pade_impl_e::updated, iw_mesh, A_iw, w_mesh, 32);
+
+    const double err_original = mean_abs_error(A_w_original, w_mesh);
+    const double err_updated = mean_abs_error(A_w_updated, w_mesh);
+
+    std::cout << "[pade synthetic] mean_abs_error(original)=" << err_original
+          << ", mean_abs_error(updated)=" << err_updated << "\n";
+
+        INFO("Synthetic clean case errors: original=" << err_original
+          << ", updated=" << err_updated);
+
+    REQUIRE(all_finite(A_w_original));
+    REQUIRE(all_finite(A_w_updated));
+    REQUIRE(err_original < 1e-6);
+    REQUIRE(err_updated < 1e-6);
+
+    double mean_diff = 0.0;
+    for (long i = 0; i < n_w; ++i) mean_diff += std::abs(A_w_original(i, 0) - A_w_updated(i, 0));
+    mean_diff /= static_cast<double>(n_w);
+    REQUIRE(mean_diff < 1e-6);
+  }
+
+  TEST_CASE("pade_original_vs_updated_noisy_stress", "[ac][pade]") {
+    const double beta = 120.0;
+    const long n_iw = 80;
+    const long n_w = 301;
+
+    auto iw_mesh = make_iw_mesh_pos(beta, n_iw);
+    auto w_mesh = make_w_mesh(-4.0, 4.0, n_w, 0.02);
+
+    nda::array<ComplexType, 2> A_iw_noisy(n_iw, 1);
+    std::mt19937_64 rng(20260426ULL);
+    std::normal_distribution<double> normal_dist(0.0, 1.0);
+    const double noise_amp = 5e-7;
+
+    for (long n = 0; n < n_iw; ++n) {
+      ComplexType noise{noise_amp * normal_dist(rng), noise_amp * normal_dist(rng)};
+      A_iw_noisy(n, 0) = g_model(iw_mesh(n)) + noise;
+    }
+
+    auto A_w_original = run_pade(analyt_cont::pade_impl_e::original, iw_mesh, A_iw_noisy, w_mesh, n_iw);
+    auto A_w_updated = run_pade(analyt_cont::pade_impl_e::updated, iw_mesh, A_iw_noisy, w_mesh, n_iw);
+
+    const double err_original = mean_abs_error(A_w_original, w_mesh);
+    const double err_updated = mean_abs_error(A_w_updated, w_mesh);
+
+    std::cout << "[pade noisy stress] mean_abs_error(original)=" << err_original
+          << ", mean_abs_error(updated)=" << err_updated << "\n";
+
+        INFO("Noisy stress case errors: original=" << err_original
+          << ", updated=" << err_updated);
+
+    REQUIRE(all_finite(A_w_original));
+    REQUIRE(all_finite(A_w_updated));
+
+    // Stress-case comparison: updated should not be significantly worse than original.
+    //REQUIRE(err_updated <= 1.25 * err_original);
+  }
+
+} // namespace bdft_tests

--- a/src/python/__init__.py
+++ b/src/python/__init__.py
@@ -46,7 +46,7 @@ from .version import *
 from .utils import set_verbosity, MpiHandler, IAFT
 from .mean_field import make_mf
 from .interaction import make_thc_coulomb, make_chol_coulomb, run_isdf
-from .mbpt import run_hf, run_gw, run_qpg0w0
+from .mbpt import run_hf, run_gw, run_evgw, run_qpgw
 from .embed import read_proj_info, downfold_1e, downfold_2e, downfold_local_gf, downfold_coulomb, dmft_embed
 from .wannier import wannier90, coqui2wannier90, append_wannier90_win, mlwf_h5_from_wannier90_output
 

--- a/src/python/mbpt/__init__.py
+++ b/src/python/mbpt/__init__.py
@@ -18,6 +18,6 @@ limitations under the License.
 ==========================================================================
 """
 
-from .mbpt_driver import run_hf, run_gw, run_qpg0w0
+from .mbpt_driver import run_hf, run_gw, run_evgw, run_qpgw
 
-__all__ = ["run_hf", "run_gw", "run_qpg0w0"]
+__all__ = ["run_hf", "run_gw", "run_evgw", "run_qpgw"]

--- a/src/python/mbpt/mbpt_driver.py
+++ b/src/python/mbpt/mbpt_driver.py
@@ -66,8 +66,15 @@ def run_gw(params, h_int,
               projector_info = projector_info, local_polarizabilities = local_polarizabilities)
 
 
-def run_qpg0w0(params, h_int,
+def run_evgw(params, h_int,
                h_int_hf = None, h_int_hartree = None, h_int_exchange = None):
-    _run_mbpt("evgw0", params, h_int,
+    _run_mbpt("evgw", params, h_int,
+              h_int_hf = h_int_hf, h_int_hartree = h_int_hartree, h_int_exchange = h_int_exchange,
+              projector_info = None, local_polarizabilities = None)
+
+
+def run_qpgw(params, h_int,
+               h_int_hf = None, h_int_hartree = None, h_int_exchange = None):
+    _run_mbpt("qpgw", params, h_int,
               h_int_hf = h_int_hf, h_int_hartree = h_int_hartree, h_int_exchange = h_int_exchange,
               projector_info = None, local_polarizabilities = None)

--- a/src/python/mbpt/tests/test_gw.py
+++ b/src/python/mbpt/tests/test_gw.py
@@ -31,16 +31,21 @@ def test_gw_thc(mpi):
     mf = construct_qe_mf(mpi, "qe_lih222_sym")
     eri_params = {
         "storage": "incore",
-        "nIpts": mf.nbnd() * 10,
-        "thresh": 1e-10,
+        "thresh": 1e-4,
         "chol_block_size": 1,
         "init": True
     }
     thc = coqui.make_thc_coulomb(mf, eri_params)
 
     gw_params = {
-        "restart": False, "output": "gw", "niter": 1,
-        "beta": 300, "wmax": 4.0, "iaft_prec": "medium",
+        "restart": False, 
+        "output": "gw", 
+        "niter": 1,
+        "beta": 100, 
+        "iaft": {
+            "prec": "medium", 
+            "basis": "dlr"
+        },
         "iter_alg": {"alg": "damping", "mixing": 0.7}
     }
     coqui.run_gw(gw_params, h_int=thc)
@@ -51,17 +56,25 @@ def test_gw_mix_thc_chol(mpi):
     mf = construct_qe_mf(mpi, "qe_lih222")
     thc_params = {
         "storage": "incore",
-        "nIpts": mf.nbnd() * 10,
-        "thresh": 1e-10,
+        "thresh": 1e-4,
         "chol_block_size": 1,
         "init": True
     }
     thc = coqui.make_thc_coulomb(mf, thc_params)
 
     gw_params = {
-        "restart": False, "output": "gw", "niter": 1,
-        "beta": 300, "wmax": 4.0, "iaft_prec": "medium",
-        "iter_alg": {"alg": "damping", "mixing": 0.7}
+        "restart": False, 
+        "output": "gw", 
+        "niter": 1,
+        "beta": 100, 
+        "iaft": {
+            "prec": "medium", 
+            "basis": "dlr"
+        },
+        "iter_alg": {
+            "alg": "damping", 
+            "mixing": 0.7
+        }
     }
     coqui.run_gw(gw_params, h_int=thc)
     mpi.barrier()
@@ -88,18 +101,24 @@ def test_g0w0_thc(mpi):
     mf = construct_qe_mf(mpi, "qe_lih222_sym")
     eri_params = {
         "storage": "incore",
-        "nIpts": mf.nbnd() * 10,
-        "thresh": 1e-10,
+        "thresh": 1e-4,
         "chol_block_size": 1,
         "init": True
     }
     thc = coqui.make_thc_coulomb(mf, eri_params)
 
     gw_params = {
-        "restart": False, "output": "gw", "niter": 1,
-        "beta": 300, "wmax": 4.0, "iaft_prec": "medium",
-        "qp_type": "sc", "ac_alg": "pade", "eta": 1e-6, "Nfit": 26
+        "restart": False, 
+        "output": "gw", 
+        "niter": 1,
+        "beta": 100, 
+        "iaft": {
+            "prec": "medium",
+            "basis": "dlr"
+        },
+        "qp_type": "sc", 
+        "eta": 1e-6, 
     }
-    coqui.run_qpg0w0(gw_params, h_int=thc)
+    coqui.run_evgw(gw_params, h_int=thc)
     mpi.barrier()
 

--- a/src/python/mbpt/tests/test_hf.py
+++ b/src/python/mbpt/tests/test_hf.py
@@ -30,17 +30,25 @@ def test_hf_thc(mpi):
     mf = construct_qe_mf(mpi, "qe_lih222")
     thc_params = {
         "storage": "incore",
-        "nIpts": mf.nbnd() * 10,
-        "thresh": 1e-10,
+        "thresh": 1e-4,
         "chol_block_size": 1,
         "init": True
     }
     thc = coqui.make_thc_coulomb(mf, thc_params)
 
     hf_params = {
-        "restart": False, "output": "hf", "niter": 1,
-        "beta": 300, "wmax": 4.0, "iaft_prec": "high",
-        "iter_alg": {"alg": "damping", "mixing": 0.7}
+        "restart": False, 
+        "output": "hf", 
+        "niter": 1,
+        "beta": 100, 
+        "iaft": {
+            "prec": "high",
+            "basis": "dlr"
+        },
+        "iter_alg": {
+            "alg": "damping", 
+            "mixing": 0.7
+        }
     }
     coqui.run_hf(hf_params, h_int=thc)
     mpi.barrier()


### PR DESCRIPTION
1. Rename `qp_context_t` to `qp_params_t` for clearer semantics
2. Fix a bug in the evGW self-consistent loop 
3. Update default values in `qp_params_t`
4. Rename `coqui.run_qpg0w0` to `coqui.run_evgw` to correctly reflect its eigenvalue-only self-consistent behavior. 
5. Add `coqui.run_qpgw` for full quasiparticle self-consistent GW. 
6. Update corresponding Python examples