### PR TITLE
Enhance 'gygi' treatment and improve error handling for dependencies

### DIFF
--- a/src/methods/GW/g0_div_utils.hpp
+++ b/src/methods/GW/g0_div_utils.hpp
@@ -139,19 +139,21 @@ namespace methods {
 
         } else if (div_treatment.find("gygi") != std::string::npos) {
 
-          app_log(1, "");
-          app_log(1, "╔═══════════════════════════════════════════════════════════════════════════════════════════╗");
-          app_log(1, "║ [ NOTE ]                                                                                  ║");
-          app_log(1, "║ The 'gygi' treatment for the inverse dielectric function has been updated.                ║");
-          app_log(1, "║ The new 'gygi' method extrapolates to q=0 using a polynomial fit of the closest q-points. ║");
-          app_log(1, "║ This provides a more accurate estimate at q=0, important for treating finite-size effects.║");
-          app_log(1, "║                                                                                           ║");
-          app_log(1, "║ You can still access the previous 'gygi' treatment (uses smallest-|q| point) via          ║");
-          app_log(1, "║ 'gygi_smallest_q'. However, this older method is less accurate and not recommended.       ║");
-          app_log(1, "╚═══════════════════════════════════════════════════════════════════════════════════════════╝\n");
+          app_log(4, "");
+          app_log(4, "╔═══════════════════════════════════════════════════════════════════════════════════════════╗");
+          app_log(4, "║ [ NOTE ]                                                                                  ║");
+          app_log(4, "║ The 'gygi' treatment for the inverse dielectric function has been updated.                ║");
+          app_log(4, "║ The new 'gygi' method extrapolates to q=0 using a polynomial fit of the closest q-points. ║");
+          app_log(4, "║ This provides a more accurate estimate at q=0, important for treating finite-size effects.║");
+          app_log(4, "║                                                                                           ║");
+          app_log(4, "║ You can still access the previous 'gygi' treatment (uses smallest-|q| point) via          ║");
+          app_log(4, "║ 'gygi_smallest_q'. However, this older method is less accurate and not recommended.       ║");
+          app_log(4, "╚═══════════════════════════════════════════════════════════════════════════════════════════╝\n");
 
-          int fit_order = 2; // default
-          // Try to extract fit_order from string: "gygi_q2_fit_{N}[_...]"
+          // default to a rather large fit order which seems to result in better extrapolation. 
+          // The actual polynomial order will be automatically reduced if not enough q-points are found along each direction.
+          int fit_order = 10; 
+          // User can specify a smaller fit order by appending "order_{N}" to div_treatment, e.g. "gygi_order_4" to use a 4th-order polynomial fit.
           const std::string order_prefix = "order_";
           auto fit_pos = div_treatment.find(order_prefix);
           if (fit_pos != std::string::npos) {
@@ -165,11 +167,11 @@ namespace methods {
           auto closest_indices = find_n_closest_per_direction(mf.Qpts_ibz(), mf.lattv(), fit_order+1);
 
           if (two_dimension)
-            app_log(2, "\n Polynomial extrapolate head of the inverse of the dielectric function as O(q^2)\n"
-                       " up to order {} using the closest {} points along +/-b1, and +/-b2 directions", fit_order, fit_order+1);
+            app_log(2, "\n Polynomial extrapolate head of the inverse of the dielectric function as O(q^2) along +/-b1, and +/-b2 directions."); 
           else
-            app_log(2, "\n Polynomial extrapolate head of the inverse of the dielectric function as O(q^2)\n"
-                       " up to order {} using the closest {} points along +/-b1, +/-b2, and +/-b3 directions", fit_order, fit_order+1);
+            app_log(2, "\n Polynomial extrapolate head of the inverse of the dielectric function as O(q^2) along +/-b1, +/-b2, and +/-b3 directions."); 
+          app_log(4, "   - Maximum polynomial fit order: {}", fit_order);
+          app_log(4, "   - Maximum number of q-points used for fit per direction: {}", fit_order+1);
           
           int dim = 0;
           constexpr std::array<const char *, 6> direction_labels = {"+b1", "-b1", "+b2", "-b2", "+b3", "-b3"};

--- a/src/python/__init__.py
+++ b/src/python/__init__.py
@@ -56,4 +56,6 @@ from . import mean_field
 from . import interaction
 from . import mbpt
 from . import embed
-from . import wannier 
+from . import wannier
+from . import post_proc
+from . import dmft

--- a/src/python/dmft/__init__.py
+++ b/src/python/dmft/__init__.py
@@ -18,11 +18,39 @@ limitations under the License.
 ==========================================================================
 """
 
-from .scf_driver import *
-from .dmft_state import *
-from .triqs_utils import *
-from .chemical_potential import *
-from .weiss import *
-from .bath_fit import *
-from .io import *
-from . import ctseg
+_TRIQS_AVAILABLE = False
+_TRIQS_CTSEG_AVAILABLE = False
+_TRIQS_IMPORT_ERROR = None
+
+try:
+  from .scf_driver import *
+  from .dmft_state import *
+  from .triqs_utils import *
+  from .chemical_potential import *
+  from .weiss import *
+  from .bath_fit import *
+  from .io import *
+  _TRIQS_AVAILABLE = True
+except ImportError as _e:
+  _TRIQS_IMPORT_ERROR = _e
+
+if _TRIQS_AVAILABLE:
+  try:
+    from . import ctseg
+    _TRIQS_CTSEG_AVAILABLE = True
+  except ImportError:
+    pass
+
+def __getattr__(name):
+  if not _TRIQS_AVAILABLE:
+    raise ImportError(
+      f"'{name}' is not available because the coqui.dmft submodule requires TRIQS core library and TRIQS/ModEST. "
+      f"Ensure TRIQS and TRIQS/ModEST are installed (https://github.com/triqs/triqs and https://github.com/TRIQS/modest). "
+      f"Original error: {_TRIQS_IMPORT_ERROR}"
+    )
+  if name == "ctseg" and not _TRIQS_CTSEG_AVAILABLE:
+    raise ImportError(
+      f"'ctseg' is not available because it requires TRIQS/CTSEG. "
+      f"Please ensure TRIQS/CTSEG is installed (https://github.com/triqs/ctseg)."
+    )
+  raise AttributeError(f"module 'coqui.dmft' has no attribute '{name}'")

--- a/src/python/dmft/tests/test_edmft.py
+++ b/src/python/dmft/tests/test_edmft.py
@@ -24,6 +24,8 @@ import os
 import numpy as np
 import pytest
 
+pytest.importorskip("triqs", reason="triqs is required for dmft tests")
+
 import coqui
 from coqui.utils.tests.test_coqui_env import mpi
 from coqui.dmft.bath_fit import causal_projection_boson

--- a/src/python/embed/tests/test_downfold.py
+++ b/src/python/embed/tests/test_downfold.py
@@ -40,9 +40,19 @@ def test_downfold(mpi):
     thc = coqui.make_thc_coulomb(mf, eri_params)
 
     gw_params = {
-        "restart": False, "output": "gw", "niter": 1,
-        "beta": 300, "wmax": 4.0, "iaft_prec": "medium",
-        "iter_alg": {"alg": "damping", "mixing": 0.7}
+        "restart": False, 
+        "output": "gw", 
+        "niter": 1,
+        "div_treatment": "gygi",
+        "beta": 100, 
+        "iaft": {
+            "prec": "medium",
+            "basis": "dlr"
+        },
+        "iter_alg": {
+            "alg": "damping", 
+            "mixing": 0.7
+        }
     }
     coqui.run_gw(gw_params, h_int=thc)
     mpi.barrier()
@@ -51,25 +61,36 @@ def test_downfold(mpi):
 
     # downfold the local Green's function
     gloc_params = {
-        "outdir": "./", "prefix": "gw",
-        "greens_func_source": "scf", "greens_func_iteration": 1,
+        "outdir": "./", 
+        "prefix": "gw",
+        "greens_func_source": "scf", 
+        "greens_func_iteration": 1,
         "wannier_file": mf.outdir() + "/lih_wan.h5",
         "force_real": True
     }
     Gloc_t = coqui.downfold_local_gf(mf, gloc_params)
 
+
+    print(f"Gloc_t[-1,0,0,0] = {Gloc_t[-1,0,0,0]}")
+    print(f"Gloc_t[-1,0,1,0] = {Gloc_t[-1,0,1,0]}")
+    print(f"Gloc_t[-1,0,1,1] = {Gloc_t[-1,0,1,1]}")
     assert np.allclose(Gloc_t.imag, 0.0, atol=1e-10), "Imaginary part of Gloc(t) is not negligible"
-    assert Gloc_t[-1,0,0,0] == pytest.approx(-0.9921589287308954, abs=1e-10)
-    assert Gloc_t[-1,0,1,0] == pytest.approx(-2.3062352653523378e-05, abs=1e-10)
-    assert Gloc_t[-1,0,1,1] == pytest.approx(-0.9677107811482517, abs=1e-10)
+    assert Gloc_t[-1,0,0,0] == pytest.approx(-0.990216810442369, abs=1e-10)
+    assert Gloc_t[-1,0,1,0] == pytest.approx(-2.0127730737525417e-05, abs=1e-10)
+    assert Gloc_t[-1,0,1,1] == pytest.approx(-0.9671840734138286, abs=1e-10)
 
     # downfold the local screened interaction
     wloc_params = {
-        "outdir": "./", "prefix": "gw",
+        "outdir": "./", 
+        "prefix": "gw",
         "screen_type": "gw_edmft_density",
-        "greens_func_source": "scf", "greens_func_iteration": 1,
+        "greens_func_source": "scf", 
+        "greens_func_iteration": 1,
         "wannier_file": mf.outdir() + "/lih_wan.h5",
-        "permut_symm": True, "force_real": True, "output_in_tau": True
+        "div_treatment": "gygi_smallest_q",
+        "permut_symm": True, 
+        "force_real": True, 
+        "output_in_tau": True
     }
     Vloc, Wloc_t = coqui.downfold_coulomb(thc, wloc_params)
 
@@ -79,21 +100,29 @@ def test_downfold(mpi):
     assert Vloc[0,1,0,1] == pytest.approx(4.286546964169289e-05, abs=1e-12)
     assert Vloc[1,1,1,1] == pytest.approx(0.5557140951494038, abs=1e-12)
 
+    print(f"Wloc_t[0,0,0,0,0] = {Wloc_t[0,0,0,0,0]}")
+    print(f"Wloc_t[0,0,0,1,1] = {Wloc_t[0,0,0,1,1]}")
+    print(f"Wloc_t[0,0,1,0,1] = {Wloc_t[0,0,1,0,1]}")
+    print(f"Wloc_t[0,1,1,1,1] = {Wloc_t[0,1,1,1,1]}")
     assert np.allclose(Wloc_t.imag, 0.0, atol=1e-12), "Imaginary part of Wloc(t) is not negligible"
-    assert Wloc_t[0,0,0,0,0] == pytest.approx(-0.2211111829995033, abs=1e-12)
-    assert Wloc_t[0,0,0,1,1] == pytest.approx(-0.04914695530722674, abs=1e-12)
-    assert Wloc_t[0,0,1,0,1] == pytest.approx(-6.936180205503474e-06, abs=1e-12)
-    assert Wloc_t[0,1,1,1,1] == pytest.approx(-0.10222080762940529, abs=1e-12)
+    assert Wloc_t[0,0,0,0,0] == pytest.approx(-0.2206215541852932, abs=1e-12)
+    assert Wloc_t[0,0,0,1,1] == pytest.approx(-0.04908133825297427, abs=1e-12)
+    assert Wloc_t[0,0,1,0,1] == pytest.approx(-6.915384193746768e-06, abs=1e-12)
+    assert Wloc_t[0,1,1,1,1] == pytest.approx(-0.10210426895593258, abs=1e-12)
 
     # downfold the cRPA local screened interaction
     wloc_params["screen_type"] = "crpa"
     Vloc, Uloc_t = coqui.downfold_coulomb(thc, wloc_params, projector_info=proj_info)
 
+    print(f"Uloc_t[0,0,0,0,0] = {Uloc_t[0,0,0,0,0]}")
+    print(f"Uloc_t[0,0,0,1,1] = {Uloc_t[0,0,0,1,1]}")
+    print(f"Uloc_t[0,0,1,0,1] = {Uloc_t[0,0,1,0,1]}")
+    print(f"Uloc_t[0,1,1,1,1] = {Uloc_t[0,1,1,1,1]}")
     assert np.allclose(Uloc_t.imag, 0.0, atol=1e-12), "Imaginary part of Uloc(t) is not negligible"
-    assert Uloc_t[0,0,0,0,0] == pytest.approx(-0.2152982864315092, abs=1e-12)
-    assert Uloc_t[0,0,0,1,1] == pytest.approx(-0.04781796525814118, abs=1e-12)
-    assert Uloc_t[0,0,1,0,1] == pytest.approx(-6.839510334289843e-06, abs=1e-12)
-    assert Uloc_t[0,1,1,1,1] == pytest.approx(-0.09688743039217523, abs=1e-12)
+    assert Uloc_t[0,0,0,0,0] == pytest.approx(-0.21483386189174042, abs=1e-12)
+    assert Uloc_t[0,0,0,1,1] == pytest.approx(-0.04774705924289125, abs=1e-12)
+    assert Uloc_t[0,0,1,0,1] == pytest.approx(-6.819360600413984e-06, abs=1e-12)
+    assert Uloc_t[0,1,1,1,1] == pytest.approx(-0.09674740361073561, abs=1e-12)
 
     if mpi.root():
         os.remove("./gw.mbpt.h5")
@@ -112,11 +141,20 @@ def test_local_coulomb_from_mf(mpi):
 
     # downfold the local screened interaction
     wloc_params = {
-        "outdir": "./", "prefix": "crpa",
+        "outdir": "./", 
+        "prefix": "crpa",
+        "beta": 100, 
+        "iaft": {
+            "prec": "medium",
+            "basis": "dlr"
+        },
         "screen_type": "crpa",
         "greens_func_source": "mf",
         "wannier_file": mf.outdir() + "/lih_wan.h5",
-        "permut_symm": True, "force_real": True, "output_in_tau": True
+        "div_treatment": "gygi",
+        "permut_symm": True, 
+        "force_real": True, 
+        "output_in_tau": True
     }
     Vloc, Wloc_t = coqui.downfold_coulomb(thc, wloc_params)
 
@@ -126,11 +164,16 @@ def test_local_coulomb_from_mf(mpi):
     assert Vloc[0,1,0,1] == pytest.approx(4.286546964169289e-05, abs=1e-12)
     assert Vloc[1,1,1,1] == pytest.approx(0.5557140951494038, abs=1e-12)
 
+
+    print(f"Wloc_t[0,0,0,0,0] = {Wloc_t[0,0,0,0,0]}")
+    print(f"Wloc_t[0,0,0,1,1] = {Wloc_t[0,0,0,1,1]}")
+    print(f"Wloc_t[0,0,1,0,1] = {Wloc_t[0,0,1,0,1]}")
+    print(f"Wloc_t[0,1,1,1,1] = {Wloc_t[0,1,1,1,1]}")
     assert np.allclose(Wloc_t.imag, 0.0, atol=1e-12), "Imaginary part of Wloc(t) is not negligible"
-    assert Wloc_t[0,0,0,0,0] == pytest.approx(-0.2058301133749745, abs=1e-12)
-    assert Wloc_t[0,0,0,1,1] == pytest.approx(-0.04205916393585766, abs=1e-12)
-    assert Wloc_t[0,0,1,0,1] == pytest.approx(-6.881435931595962e-06, abs=1e-12)
-    assert Wloc_t[0,1,1,1,1] == pytest.approx(-0.08689366256595832, abs=1e-12)
+    assert Wloc_t[0,0,0,0,0] == pytest.approx(-0.2047780731982674, abs=1e-12)
+    assert Wloc_t[0,0,0,1,1] == pytest.approx(-0.04195005851002771, abs=1e-12)
+    assert Wloc_t[0,0,1,0,1] == pytest.approx(-6.82550064519015e-06, abs=1e-12)
+    assert Wloc_t[0,1,1,1,1] == pytest.approx(-0.08664882474619286, abs=1e-12)
 
     if mpi.root():
         os.remove("./crpa.mbpt.h5")

--- a/src/python/embed/tests/test_downfold.py
+++ b/src/python/embed/tests/test_downfold.py
@@ -70,10 +70,6 @@ def test_downfold(mpi):
     }
     Gloc_t = coqui.downfold_local_gf(mf, gloc_params)
 
-
-    print(f"Gloc_t[-1,0,0,0] = {Gloc_t[-1,0,0,0]}")
-    print(f"Gloc_t[-1,0,1,0] = {Gloc_t[-1,0,1,0]}")
-    print(f"Gloc_t[-1,0,1,1] = {Gloc_t[-1,0,1,1]}")
     assert np.allclose(Gloc_t.imag, 0.0, atol=1e-10), "Imaginary part of Gloc(t) is not negligible"
     assert Gloc_t[-1,0,0,0] == pytest.approx(-0.990216810442369, abs=1e-10)
     assert Gloc_t[-1,0,1,0] == pytest.approx(-2.0127730737525417e-05, abs=1e-10)
@@ -100,10 +96,6 @@ def test_downfold(mpi):
     assert Vloc[0,1,0,1] == pytest.approx(4.286546964169289e-05, abs=1e-12)
     assert Vloc[1,1,1,1] == pytest.approx(0.5557140951494038, abs=1e-12)
 
-    print(f"Wloc_t[0,0,0,0,0] = {Wloc_t[0,0,0,0,0]}")
-    print(f"Wloc_t[0,0,0,1,1] = {Wloc_t[0,0,0,1,1]}")
-    print(f"Wloc_t[0,0,1,0,1] = {Wloc_t[0,0,1,0,1]}")
-    print(f"Wloc_t[0,1,1,1,1] = {Wloc_t[0,1,1,1,1]}")
     assert np.allclose(Wloc_t.imag, 0.0, atol=1e-12), "Imaginary part of Wloc(t) is not negligible"
     assert Wloc_t[0,0,0,0,0] == pytest.approx(-0.2206215541852932, abs=1e-12)
     assert Wloc_t[0,0,0,1,1] == pytest.approx(-0.04908133825297427, abs=1e-12)
@@ -114,10 +106,6 @@ def test_downfold(mpi):
     wloc_params["screen_type"] = "crpa"
     Vloc, Uloc_t = coqui.downfold_coulomb(thc, wloc_params, projector_info=proj_info)
 
-    print(f"Uloc_t[0,0,0,0,0] = {Uloc_t[0,0,0,0,0]}")
-    print(f"Uloc_t[0,0,0,1,1] = {Uloc_t[0,0,0,1,1]}")
-    print(f"Uloc_t[0,0,1,0,1] = {Uloc_t[0,0,1,0,1]}")
-    print(f"Uloc_t[0,1,1,1,1] = {Uloc_t[0,1,1,1,1]}")
     assert np.allclose(Uloc_t.imag, 0.0, atol=1e-12), "Imaginary part of Uloc(t) is not negligible"
     assert Uloc_t[0,0,0,0,0] == pytest.approx(-0.21483386189174042, abs=1e-12)
     assert Uloc_t[0,0,0,1,1] == pytest.approx(-0.04774705924289125, abs=1e-12)
@@ -164,11 +152,6 @@ def test_local_coulomb_from_mf(mpi):
     assert Vloc[0,1,0,1] == pytest.approx(4.286546964169289e-05, abs=1e-12)
     assert Vloc[1,1,1,1] == pytest.approx(0.5557140951494038, abs=1e-12)
 
-
-    print(f"Wloc_t[0,0,0,0,0] = {Wloc_t[0,0,0,0,0]}")
-    print(f"Wloc_t[0,0,0,1,1] = {Wloc_t[0,0,0,1,1]}")
-    print(f"Wloc_t[0,0,1,0,1] = {Wloc_t[0,0,1,0,1]}")
-    print(f"Wloc_t[0,1,1,1,1] = {Wloc_t[0,1,1,1,1]}")
     assert np.allclose(Wloc_t.imag, 0.0, atol=1e-12), "Imaginary part of Wloc(t) is not negligible"
     assert Wloc_t[0,0,0,0,0] == pytest.approx(-0.2047780731982674, abs=1e-12)
     assert Wloc_t[0,0,0,1,1] == pytest.approx(-0.04195005851002771, abs=1e-12)

--- a/src/python/post_proc/__init__.py
+++ b/src/python/post_proc/__init__.py
@@ -19,15 +19,45 @@ limitations under the License.
 """
 
 from .post_proc import (
-    ac,
-    band_interpolation,
-    spectral_interpolation,
-    local_dos,
-    unfold_bz,
-    dump_vxc,
-    dump_hartree
+  ac,
+  band_interpolation,
+  spectral_interpolation,
+  local_dos,
+  unfold_bz,
+  dump_vxc,
+  dump_hartree
 )
+from . import plot_utils
 
-__all__ = ["ac", "band_interpolation", "spectral_interpolation",
-           "local_dos", "unfold_bz", "dump_vxc", "dump_hartree",
-           "plot_utils"]
+_TRIQS_AVAILABLE = False
+_TRIQS_IMPORT_ERROR = None
+
+try:
+  from .analytic_cont import (
+    maxent_sigma,
+    maxent_sigma_k,
+  )
+  _TRIQS_AVAILABLE = True
+except ImportError as _e:
+  _TRIQS_IMPORT_ERROR = _e
+
+# Names from analytic_cont that require TRIQS
+_TRIQS_AC_NAMES = frozenset(["maxent_sigma", "maxent_sigma_k"])
+
+def __getattr__(name):
+  if name in _TRIQS_AC_NAMES:
+    raise ImportError(
+      f"'{name}' is not available because it requires TRIQS. "
+      f"Ensure TRIQS is installed (https://triqs.github.io). "
+      f"Original error: {_TRIQS_IMPORT_ERROR}"
+    )
+  raise AttributeError(f"module 'coqui.post_proc' has no attribute '{name}'")
+
+__all__ = [
+  "ac", "band_interpolation", "spectral_interpolation",
+  "local_dos", "unfold_bz", "dump_vxc", "dump_hartree",
+  "plot_utils",
+]
+
+if _TRIQS_AVAILABLE:
+  __all__.extend(["maxent_sigma", "maxent_sigma_k"])

--- a/src/python/post_proc/analytic_cont.py
+++ b/src/python/post_proc/analytic_cont.py
@@ -21,13 +21,7 @@ limitations under the License.
 import sys
 import numpy as np
 from h5 import HDFArchive
-
-try:
-    from triqs.gf import *
-except ImportError:
-    raise ImportError("Fails to import triqs! \n"
-                      "The utility functions in the AC module requires triqs package. \n"
-                      "(https://github.com/TRIQS/triqs). Please ensure that it is installed. ")
+from triqs.gf import *
 
 """ 
 Analytical continuation utilities based on TRIQS application  


### PR DESCRIPTION
1. Update default `gygi` treatment for the inverse dielectric function using a higher-order polynomial fit. 
2. Add import guards and clearer error messages for missing Python dependencies.  