### PR TITLE
update default ecut in THC construction

### DIFF
--- a/examples/toml_input_interface/interaction/isdf_thc_eri.toml
+++ b/examples/toml_input_interface/interaction/isdf_thc_eri.toml
@@ -26,7 +26,8 @@ ecut            = 60               # [optional] Energy cutoff in the evaluation 
                                    #            charge density, sometimes even for wfc. Fine-tuning
                                    #            this value can significantly reduce the computational
                                    #            cost and memory requiremtnt.
-                                   #            Default = ecut for charge density.
+                                   #            Default = 1.4 x wfc cutoff (falls back to
+                                   #            0.4 x charge-density cutoff when no wfc grid).
 save            = "thc_eri.h5"     # [optional] h5 archive to store the THC outputs;
                                    #            default = "", i.e. not to store on the disk
 storage         = "incore"         # [optional] this determines how THC will be accessed in the

--- a/src/methods/ERI/thc.cpp
+++ b/src/methods/ERI/thc.cpp
@@ -89,7 +89,8 @@ auto make_wfc_to_rho(utils::mpi_context_t<mpi3::communicator>& mpi,
 /*
  * Creates a thc object with arguments in property tree.
  *  Important options:
- *  - ecut: "0.4 * ecutrho", Plane wave cutoff used for the evaluation of coulomb matrix elements.
+ *  - ecut: "1.4 * ecutwfc" (falls back to "0.4 * ecutrho" when no wfc grid is available),
+ *          Plane wave cutoff used for the evaluation of coulomb matrix elements.
  *  - thresh: "1e-5", Threshold in cholesky decomposition.
  *  Performance related options:
  *  - matrix_block_size: 1024, Block size used in distributed arrays.
@@ -106,7 +107,8 @@ thc::thc(mf::MF *mf_,
   mpi(std::addressof(mpi_)),
   mf(mf_),
   Timer(),
-  ecut( io::get_value_with_default<double>(pt,"ecut",0.4*mf->ecutrho()) ),
+  ecut( io::get_value_with_default<double>(pt,"ecut",
+          mf->has_wfc_grid() ? 1.4*mf->wfc_truncated_grid()->ecut() : 0.4*mf->ecutrho()) ),
   rho_g( detail::make_grid(mpi->comm,ecut,*mf) ),
   swfc_to_rho(detail::make_wfc_to_rho(*mpi,(mf->has_wfc_grid()?*(mf->wfc_truncated_grid()):rho_g),rho_g)),
   vG( io::check_child_exists(pt,"potential") ? io::find_child(pt,"potential") : ptree{}),

--- a/src/methods/ERI/thc.h
+++ b/src/methods/ERI/thc.h
@@ -69,7 +69,8 @@ class thc
   /*
    * Creates a thc object with arguments in property tree.
    *  Important options:
-   *  - ecut: "0.4 * ecutrho", Plane wave cutoff used for the evaluation of coulomb matrix elements.
+   *  - ecut: "1.4 * ecutwfc" (falls back to "0.4 * ecutrho" when no wfc grid is available),
+   *          Plane wave cutoff used for the evaluation of coulomb matrix elements.
    *  - thresh: "1e-5", Threshold in cholesky decomposition.
    *  Performance related options:
    *  - matrix_block_size: 1024, Block size used in distributed arrays.

--- a/src/python/interaction/thc.py
+++ b/src/python/interaction/thc.py
@@ -50,8 +50,10 @@ def make_thc_coulomb(mf, params):
           Defaults to ``1e-5`` when ``nIpts=0`` or to ``1e-13`` when ``nIpts > 0``. 
           When both ``nIpts`` and ``thresh`` are given explicitly, the algorithm stops 
           as soon as either criterion is satisfied.
-        - ``ecut`` *(float, optional, default ``0.4 * mf.ecutrho()``)* - kinetic-energy 
-          cutoff for evaluating Coulomb matrix elements.
+        - ``ecut`` *(float, optional, default ``1.4 * mf.ecutwfc()``)* - kinetic-energy
+          cutoff for evaluating Coulomb matrix elements. For backends without a
+          wavefunction grid (e.g. PySCF, model), the default falls back to
+          ``0.4 * mf.ecutrho()``.
         - ``storage`` *(str, optional, default ``"incore"``)* — how integrals are
           stored after construction. ``"incore"`` keeps them in memory;
           ``"outcore"`` reads them from the HDF5 file on demand.


### PR DESCRIPTION
The previous energy cutoff for THC integral construction is `0.4*ecutrho` which is often too conservative to practical calculations. This PR updates the default value from `0.4*ecutrho` to `1.4*ecutwfc`. 