### PR TITLE
Improve DMFT input handling and h5 library compatibility

### DIFF
--- a/src/methods/pproc/pproc_t.cpp
+++ b/src/methods/pproc/pproc_t.cpp
@@ -313,6 +313,11 @@ namespace methods {
       Heff_path = grp_name + "/iter" + std::to_string(iter) + (iter_grp.has_subgroup("qp_approx")? "/qp_approx/Heff_skij" : "/Heff_skij");
     }
     _context.comm.broadcast_n(&mu, 1, 0);
+    // broadcast_n() does not communicate `count` argrument, 
+    // we must ensure all ranks have the same Heff_path.size() before broadcasting Heff_path.data().
+    long Heff_path_size = Heff_path.size();
+    _context.comm.broadcast_n(&Heff_path_size, 1, 0);
+    if (!_context.comm.root()) Heff_path.resize(Heff_path_size);
     _context.comm.broadcast_n(Heff_path.data(), Heff_path.size(), 0);
     _context.comm.broadcast_n(&iter, 1, 0);
 

--- a/src/python/dmft/io.py
+++ b/src/python/dmft/io.py
@@ -30,11 +30,11 @@ def convert_gw_edmft_params(gw_edmft_params: dict):
 
     # Copy top-level gw_edmft settings
     gw_edmft_params = {}
-    niter = gw_edmft_group.get('niter')
-    gw_iter_per_loop = gw_edmft_group.get('gw_iter_per_loop', 1)
-    edmft_iter_per_loop = gw_edmft_group.get('edmft_iter_per_loop', 1)
-    if gw_edmft_group.get('wannier_file'):
-        gw_edmft_params['wannier_file'] = gw_edmft_group.get('wannier_file')
+    niter = gw_edmft_group.pop('niter')
+    gw_iter_per_loop = gw_edmft_group.pop('gw_iter_per_loop', 1)
+    edmft_iter_per_loop = gw_edmft_group.pop('edmft_iter_per_loop', 1)
+    if 'wannier_file' in gw_edmft_group:
+        gw_edmft_params['wannier_file'] = gw_edmft_group.pop('wannier_file')
     if niter is None:
         raise KeyError("Missing 'niter' parameter to specify the total number of GW+EDMFT cycles.")
     if not isinstance(niter, int) or niter <= 0:
@@ -58,13 +58,13 @@ def convert_gw_edmft_params(gw_edmft_params: dict):
     gw_edmft_params['gw_iter_per_loop'] = gw_iter_per_loop
     gw_edmft_params['edmft_iter_per_loop'] = edmft_iter_per_loop
     
-    screen_type = gw_edmft_group.get('screen_type', 'gw_edmft')
-    div_treatment = gw_edmft_group.get('div_treatment', 'gygi')
-    outdir = gw_edmft_group.get('outdir', './')
-    prefix = gw_edmft_group.get('prefix', 'coqui')
+    screen_type = gw_edmft_group.pop('screen_type', 'gw_edmft')
+    div_treatment = gw_edmft_group.pop('div_treatment', 'gygi')
+    outdir = gw_edmft_group.pop('outdir', './')
+    prefix = gw_edmft_group.pop('prefix', 'coqui')
     # restart = False implies the workflow will start from a fresh checkpoint where both GW and EDMFT parts start from scratch;
     # this is not available yet in the current implementation as the GW part is always assumed to restart from a previous checkpoint.
-    restart = gw_edmft_group.get('restart', True)
+    restart = gw_edmft_group.pop('restart', True)
     if restart is False:
         raise NotImplementedError(
             "Starting the GW+EDMFT workflow from scratch (restart=False) is not implemented yet. " \
@@ -110,7 +110,7 @@ def convert_gw_edmft_params(gw_edmft_params: dict):
     # embed parameters
     gw_edmft_params['dmft_embed'] = {
         'outdir': outdir, 'prefix': prefix, 
-        'corr_only': gw_edmft_group.get('corr_only', True), 
+        'corr_only': gw_edmft_group.pop('corr_only', True),
         # disable iterative solver for the embedding step. The iterative solve happens somewhere else. 
         'iter_alg': {'enable': False} 
     }
@@ -125,6 +125,10 @@ def convert_gw_edmft_params(gw_edmft_params: dict):
         'iter_alg': edmft_iter_params,
         'chkpt_h5': edmft_section.pop('chkpt_h5', outdir+"/"+prefix+".mbpt.h5")
     }
+
+    if 'iaft' in gw_edmft_group:
+        iaft_params = gw_edmft_group.pop('iaft')
+        gw_edmft_params['impurity']['iaft'] = iaft_params
   
     # Convert 'impurity' (new) to 'solver' (old)
     if 'impurity' in edmft_section:
@@ -133,14 +137,18 @@ def convert_gw_edmft_params(gw_edmft_params: dict):
             solver_list = [solver_list]
     
         for solver_params in solver_list:
-            if solver_params.get('degenerate_blk'):
+            if 'degenerate_blk' in solver_params:
                 solver_params['degenerate_blk'] = [np.array(x) for x in solver_params['degenerate_blk']]
         
         gw_edmft_params['impurity']['solver'] = solver_list
 
-    # Copy any remaining keys
+    # Copy any remaining keys in the edmft section
     for key, value in edmft_section.items():
         gw_edmft_params['impurity'][key] = value
+
+    # Copy any remaining keys in the top-level gw_edmft section
+    for key, value in gw_edmft_group.items():
+        gw_edmft_params[key] = value
 
     return gw_edmft_params
 

--- a/src/python/dmft/io.py
+++ b/src/python/dmft/io.py
@@ -30,13 +30,13 @@ def convert_gw_edmft_params(gw_edmft_params: dict):
 
     # Copy top-level gw_edmft settings
     gw_edmft_params = {}
+    if 'niter' not in gw_edmft_group:
+        raise KeyError("'niter' is required: specify the total number of GW+EDMFT cycles as a positive integer.")
     niter = gw_edmft_group.pop('niter')
     gw_iter_per_loop = gw_edmft_group.pop('gw_iter_per_loop', 1)
     edmft_iter_per_loop = gw_edmft_group.pop('edmft_iter_per_loop', 1)
     if 'wannier_file' in gw_edmft_group:
         gw_edmft_params['wannier_file'] = gw_edmft_group.pop('wannier_file')
-    if niter is None:
-        raise KeyError("Missing 'niter' parameter to specify the total number of GW+EDMFT cycles.")
     if not isinstance(niter, int) or niter <= 0:
         raise ValueError("'niter' must be a positive integer.")
     if not isinstance(gw_iter_per_loop, int) or gw_iter_per_loop < 0:

--- a/src/python/dmft/plot.py
+++ b/src/python/dmft/plot.py
@@ -126,6 +126,8 @@ def plot_edmft_convergence(dmft_chkpt, *, impurity_index=0, check_w=True,
       iter_grp = dmft_grp[ik]
       if imp_key not in iter_grp.keys():
         continue
+      if "results" not in iter_grp[imp_key].keys():
+        continue
       res_grp = iter_grp[f"{imp_key}/results"]
 
       if "convergence" not in res_grp.keys():

--- a/src/python/dmft/scf_driver.py
+++ b/src/python/dmft/scf_driver.py
@@ -513,7 +513,7 @@ def _edmft_loop(mf, h_int, proj_info, dmft_state, solver_chkpt_h5, coqui_chkpt_h
             # mixing impurity and dc solutions to facilitate convergence
             dmft_state.damp_impurity_results(
                 solver_chkpt_h5, mixing=iterative_params.get('mixing', 0.7), impurity_indices=[imp_index],
-                mix_in_first_iter=iterative_params.get('mix_in_first_iter', False)
+                mix_in_first_iter=iterative_params.get('mix_in_first_iter', True)
             )
 
             # save solver results for current impurity
@@ -783,7 +783,7 @@ def _solver_inner_loop(coqui_mpi, h0, delta_iw, u_weiss_iw, h_int,
         if mu_params.get('solver_output_file'):
             dens_solver_params['solver_output_file'] = mu_params.get('solver_output_file')
         if mu_params.get('n_warmup_cycles'):
-            dens_solver_params['n_warmup_cycles'] = mu_params.get('n_warmup_cycles')
+            dens_solver_params['n_warmup_cycles'] = int(mu_params.get('n_warmup_cycles'))
         if mu_params.get('length_cycle'):
             dens_solver_params['length_cycle'] = mu_params.get('length_cycle')
         dens_solver_params['n_cycles'] = mu_params.get('n_cycles', solver_params.get('n_cycles')*0.05)
@@ -932,13 +932,14 @@ def solve_impurities_from_chkpt(coqui_mpi, *, dmft_iteration=-1, imp_indices=Non
     params = convert_gw_edmft_params(params)
     
     imp_params = params.pop('impurity')
+    imp_iaft_params = imp_params.pop('iaft', {})
+
     # Scale Monte-Carlo cycle counts by MPI communicator size.
     solver_params_list = _normalize_solver_params_list(
         imp_params['solver'], coqui_mpi.comm_size()
     )
 
     iaft = IAFT.from_coqui_chkpt(imp_params['chkpt_h5'], verbose=coqui_mpi.root())
-    imp_iaft_params = imp_params.pop('iaft', {})
 
     solver_inputs = coqui_dmft.read_impurity_chkpt(
         imp_params['chkpt_h5'], dmft_iteration, read="inputs", impurity_indices=imp_indices
@@ -999,7 +1000,7 @@ def solve_impurities_from_chkpt(coqui_mpi, *, dmft_iteration=-1, imp_indices=Non
             coqui_dmft.print_degenerate_blks(degenerate_blk, Input['gf_struct'])
             delta_iw   = modest.symmetrize(delta_iw, degenerate_blk)
             h0         = coqui_dmft.symmetrize_h0_op(h0, degenerate_blk, Input['gf_struct'])
-            h_int      = coqui_dmft.symmetrize_h_int_op(h_int, degenerate_blk, Res['gf_struct'])
+            h_int      = coqui_dmft.symmetrize_h_int_op(h_int, degenerate_blk, Input['gf_struct'])
             u_weiss_iw = coqui_dmft.symmetrize_blk2_gf(u_weiss_iw, degenerate_blk, Input['gf_struct'])
 
         # Call impurity solver, and store sigma_imp, vhf_imp, and pi_imp in "Res"

--- a/src/python/interaction/pyscf_interface/gdf_converter.py
+++ b/src/python/interaction/pyscf_interface/gdf_converter.py
@@ -20,7 +20,7 @@ limitations under the License.
 
 import os
 import numpy as np
-import h5._h5py as h5
+import h5
 
 from pyscf import lib
 from pyscf.pbc import gto, df
@@ -121,37 +121,37 @@ def gdf_dump_to_h5(gdf, mo=False, outdir=None, qpts=None, qk_to_kmq=None):
     if not os.path.exists(outdir):
         os.system("mkdir " + outdir)
     filename = outdir + '/chol_info.h5'
-    f = h5.File(filename, 'w')
-    g = h5.Group(f).create_group("Interaction")
-    h5.h5_write(g, 'Np', np.int32(Naux))
-    h5.h5_write(g, "tol", -1.0)
-    h5.h5_write(g, 'nkpts', np.int32(nkpts))
-    h5.h5_write(g, 'nbnd', np.int32(nbnd))
-    h5.h5_write(g, 'kpts', gdf.kpts)
-    h5.h5_write(g, 'qpts', qpts)
-    h5.h5_write(g, 'qk_to_kmq', qk_to_kmq.astype(np.int32))
-    del f
+    with h5.HDFArchive(filename, 'w') as root:
+        root.create_group("Interaction")
+        g = root["Interaction"]
+        g['Np'] = np.int32(Naux)
+        g["tol"] = -1.0
+        g['nkpts'] = np.int32(nkpts)
+        g['nbnd'] = np.int32(nbnd)
+        g['kpts'] = gdf.kpts
+        g['qpts'] = qpts
+        g['qk_to_kmq'] = qk_to_kmq.astype(np.int32)
 
     # loop over q-points: extract V(k, k-q)(Q, i, j)
     V_Qskij = np.zeros((Naux, 1, nkpts, nbnd, nbnd), dtype=complex)
     for iq in range(nqpts):
         filename = outdir + "/Vq{}.h5".format(iq)
-        f = h5.File(filename, 'w')
-        g = h5.Group(f).create_group("Interaction")
-        h5.h5_write(g, "Np", np.int32(Naux))
-        for ik in range(nkpts):
-            ikk = qk_to_kmq[iq, ik]
-            k, kmq = gdf.kpts[ik], gdf.kpts[ikk]
-            Q_loc = 0
-            for bufferR, bufferI, sign in gdf.sr_loop((k, kmq), compact=False):
-                X = (bufferR + bufferI*1j)
-                X = X.reshape(-1, nbnd, nbnd)
-                Qsize = X.shape[0]
-                V_Qskij[Q_loc:Q_loc+Qsize,0,ik] = X
-                Q_loc += Qsize
-        h5.h5_write(g, 'Vq{}'.format(iq), V_Qskij)
+        with h5.HDFArchive(filename, 'w') as root:
+            root.create_group("Interaction")
+            g = root["Interaction"]
+            g["Np"] = np.int32(Naux)
+            for ik in range(nkpts):
+                ikk = qk_to_kmq[iq, ik]
+                k, kmq = gdf.kpts[ik], gdf.kpts[ikk]
+                Q_loc = 0
+                for bufferR, bufferI, sign in gdf.sr_loop((k, kmq), compact=False):
+                    X = (bufferR + bufferI*1j)
+                    X = X.reshape(-1, nbnd, nbnd)
+                    Qsize = X.shape[0]
+                    V_Qskij[Q_loc:Q_loc+Qsize,0,ik] = X
+                    Q_loc += Qsize
+            g['Vq{}'.format(iq)] = V_Qskij
         V_Qskij[:] = 0.0
-        del f
 
 
 def mol_gdf_dump_to_h5(gdf, mo=False, outdir=None):
@@ -177,35 +177,35 @@ def mol_gdf_dump_to_h5(gdf, mo=False, outdir=None):
     if not os.path.exists(outdir):
         os.system("mkdir " + outdir)
     filename = outdir + '/chol_info.h5'
-    f = h5.File(filename, 'w')
-    g = h5.Group(f).create_group("Interaction")
-    h5.h5_write(g, 'Np', np.int32(Naux))
-    h5.h5_write(g, "tol", -1.0)
-    h5.h5_write(g, 'nkpts', np.int32(nkpts))
-    h5.h5_write(g, 'nbnd', np.int32(nbnd))
-    h5.h5_write(g, 'kpts', kpts)
-    h5.h5_write(g, 'qpts', qpts)
-    h5.h5_write(g, 'qk_to_kmq', qk_to_kmq.astype(np.int32))
-    del f
+    with h5.HDFArchive(filename, 'w') as root:
+        root.create_group("Interaction")
+        g = root["Interaction"]
+        g['Np'] = np.int32(Naux)
+        g["tol"] = -1.0
+        g['nkpts'] = np.int32(nkpts)
+        g['nbnd'] = np.int32(nbnd)
+        g['kpts'] = kpts
+        g['qpts'] = qpts
+        g['qk_to_kmq'] = qk_to_kmq.astype(np.int32)
 
     # loop over q-points: extract V(k, k-q)(Q, i, j)
     V_Qskij = np.zeros((Naux, 1, nkpts, nbnd, nbnd), dtype=complex)
     filename = outdir + "/Vq0.h5"
-    f = h5.File(filename, 'w')
-    g = h5.Group(f).create_group("Interaction")
-    h5.h5_write(g, "Np", np.int32(Naux))
-    Q_loc = 0
-    for L in gdf.loop():
-        # L = (Naux, nbnd*(nbnd+1)//2)
-        print("Shape of eri = ", L.shape)
-        L_unpack = lib.unpack_tril(L, lib.SYMMETRIC, axis=1)
-        print("Shape of unpack eri = ", L_unpack.shape)
-        Q_size = L_unpack.shape[0]
-        V_Qskij[Q_loc:Q_loc+Q_size,0,0] = L_unpack
-        Q_loc += Q_size
-    h5.h5_write(g, 'Vq0', V_Qskij)
+    with h5.HDFArchive(filename, 'w') as root:
+        root.create_group("Interaction")
+        g = root["Interaction"]
+        g["Np"] = np.int32(Naux)
+        Q_loc = 0
+        for L in gdf.loop():
+            # L = (Naux, nbnd*(nbnd+1)//2)
+            print("Shape of eri = ", L.shape)
+            L_unpack = lib.unpack_tril(L, lib.SYMMETRIC, axis=1)
+            print("Shape of unpack eri = ", L_unpack.shape)
+            Q_size = L_unpack.shape[0]
+            V_Qskij[Q_loc:Q_loc+Q_size,0,0] = L_unpack
+            Q_loc += Q_size
+        g['Vq0'] = V_Qskij
     V_Qskij[:] = 0.0
-    del f
 
 
 

--- a/src/python/mean_field/pyscf_interface/converter.py
+++ b/src/python/mean_field/pyscf_interface/converter.py
@@ -21,7 +21,7 @@ limitations under the License.
 import os
 from functools import reduce
 import numpy as np
-import h5._h5py as h5
+import h5
 
 from pyscf import lib
 from pyscf.pbc.df import ft_ao
@@ -128,41 +128,39 @@ def dump_to_h5(mf, mo=False, outdir='./', prefix='pyscf', nbnd_out=None):
   if nbnd_out is None:
     nbnd_out = nbnd
 
-  f = h5.File(filename, 'w')
-  g = h5.Group(f)
+  with h5.HDFArchive(filename, 'w') as g:
+    g['nkpts'] = np.int32(nkpts)
+    g['nbnd'] = np.int32(nbnd_out)
+    g['nspin'] = np.int32(nspin)
+    g['nspin_in_basis'] = np.int32(nspin_in_basis)
+    g['natoms'] = np.int32(natoms)
+    g['species'] = species
+    g['nspecies'] = np.int32(nspecies)
+    g['nelec'] = np.float64(mf.cell.nelectron)
+    g['at_ids'] = charges.astype(np.int32)
+    g['at_pos'] = coords
+    g['latt'] = mf.cell.lattice_vectors()
+    g['recv'] = b  # a*b = 2*pi
+    g['kp_grid'] = kp_grid.astype(np.int32)
+    g['kpts'] = mf.kpts  # in absolute unit
+    g['k_weight'] = np.ones(len(mf.kpts), dtype=float)/len(mf.kpts)
+    g['madelung'] = tools.pbc.madelung(mf.cell, mf.kpts)
+    g['enuc'] = mf.cell.energy_nuc()
 
-  h5.h5_write(g, 'nkpts', np.int32(nkpts))
-  h5.h5_write(g, 'nbnd', np.int32(nbnd_out))
-  h5.h5_write(g, 'nspin', np.int32(nspin))
-  h5.h5_write(g, 'nspin_in_basis', np.int32(nspin_in_basis))
-  h5.h5_write(g, 'natoms', np.int32(natoms))
-  h5.h5_write(g, 'species', species)
-  h5.h5_write(g, 'nspecies', np.int32(nspecies))
-  h5.h5_write(g, 'nelec', np.float64(mf.cell.nelectron) )
-  h5.h5_write(g, 'at_ids', charges.astype(np.int32))
-  h5.h5_write(g, 'at_pos', coords)
-  h5.h5_write(g, 'latt', mf.cell.lattice_vectors() )
-  h5.h5_write(g, 'recv', b) # a*b = 2*pi
-  h5.h5_write(g, 'kp_grid', kp_grid.astype(np.int32) )
-  h5.h5_write(g, 'kpts', mf.kpts) # in absolute unit
-  h5.h5_write(g, 'k_weight', np.ones(len(mf.kpts), dtype=float)/len(mf.kpts) )
-  h5.h5_write(g, 'madelung', tools.pbc.madelung(mf.cell, mf.kpts))
-  h5.h5_write(g, 'enuc', mf.cell.energy_nuc())
+    g.create_group("FFT")
+    fft_g = g["FFT"]
+    fft_g['ecut'] = ecut
+    fft_g['fft_mesh'] = mesh.astype(np.int32)
 
-  fft_g = g.create_group("FFT")
-  h5.h5_write(fft_g, 'ecut', ecut)
-  h5.h5_write(fft_g, 'fft_mesh', mesh.astype(np.int32))
-
-  scf_g = g.create_group("SCF")
-  h5.h5_write(scf_g, 'ovlp', S[:,:,:nbnd_out,:nbnd_out])
-  h5.h5_write(scf_g, 'H0', H0[:,:,:nbnd_out,:nbnd_out])
-  h5.h5_write(scf_g, 'Fock', F[:,:,:nbnd_out,:nbnd_out])
-  h5.h5_write(scf_g, 'dm', dm[:,:,:nbnd_out,:nbnd_out])
-  h5.h5_write(scf_g, 'mo_coeff', mo_coeff[:,:,:nbnd_out,:nbnd_out])
-  h5.h5_write(scf_g, 'eigval', mo_energy[:,:,:nbnd_out])
-  h5.h5_write(scf_g, 'occ', mo_occ[:,:,:nbnd_out])
-
-  del f
+    g.create_group("SCF")
+    scf_g = g["SCF"]
+    scf_g['ovlp'] = S[:,:,:nbnd_out,:nbnd_out]
+    scf_g['H0'] = H0[:,:,:nbnd_out,:nbnd_out]
+    scf_g['Fock'] = F[:,:,:nbnd_out,:nbnd_out]
+    scf_g['dm'] = dm[:,:,:nbnd_out,:nbnd_out]
+    scf_g['mo_coeff'] = mo_coeff[:,:,:nbnd_out,:nbnd_out]
+    scf_g['eigval'] = mo_energy[:,:,:nbnd_out]
+    scf_g['occ'] = mo_occ[:,:,:nbnd_out]
 
   dump_orb(outdir+"/Orb_fft", Orb_G[:,:nbnd_out])
 
@@ -268,40 +266,39 @@ def mol_dump_to_h5(mf, becke_grid_level=3, mo=False, outdir='./', prefix='pyscf'
   if nbnd_out is None:
     nbnd_out = nbnd
 
-  f = h5.File(filename, 'w')
-  g = h5.Group(f)
+  with h5.HDFArchive(filename, 'w') as g:
+    g['nkpts'] = np.int32(nkpts)
+    g['nbnd'] = np.int32(nbnd_out)
+    g['nspin'] = np.int32(nspin)
+    g['nspin_in_basis'] = np.int32(nspin_in_basis)
+    g['natoms'] = np.int32(natoms)
+    g['species'] = species
+    g['nspecies'] = np.int32(nspecies)
+    g['nelec'] = np.float64(mf.mol.nelectron)
+    g['at_ids'] = charges.astype(np.int32)
+    g['at_pos'] = coords
+    g['latt'] = np.eye(3, dtype=float)
+    g['recv'] = 2*np.pi*np.eye(3, dtype=float)  # a*b = 2*pi
+    g['kpts'] = np.zeros((1,3), dtype=float)  # in absolute unit
+    g['k_weight'] = np.ones(1, dtype=float)
+    g['madelung'] = 0.0
+    g['enuc'] = mf.mol.energy_nuc()
 
-  h5.h5_write(g, 'nkpts', np.int32(nkpts))
-  h5.h5_write(g, 'nbnd', np.int32(nbnd_out))
-  h5.h5_write(g, 'nspin', np.int32(nspin))
-  h5.h5_write(g, 'nspin_in_basis', np.int32(nspin_in_basis))
-  h5.h5_write(g, 'natoms', np.int32(natoms))
-  h5.h5_write(g, 'species', species)
-  h5.h5_write(g, 'nspecies', np.int32(nspecies))
-  h5.h5_write(g, 'nelec', np.float64(mf.mol.nelectron) )
-  h5.h5_write(g, 'at_ids', charges.astype(np.int32))
-  h5.h5_write(g, 'at_pos', coords)
-  h5.h5_write(g, 'latt', np.eye(3, dtype=float))
-  h5.h5_write(g, 'recv', 2*np.pi*np.eye(3, dtype=float)) # a*b = 2*pi
-  h5.h5_write(g, 'kpts', np.zeros((1,3), dtype=float)) # in absolute unit
-  h5.h5_write(g, 'k_weight', np.ones(1, dtype=float))
-  h5.h5_write(g, 'madelung', 0.0)
-  h5.h5_write(g, 'enuc', mf.mol.energy_nuc())
+    g.create_group("BECKE")
+    becke_g = g["BECKE"]
+    becke_g['r_grid'] = r_grid
+    becke_g['weight'] = becke_weights
+    becke_g['number_of_rpoints'] = np.int32(becke_weights.shape[0])
 
-  becke_g = g.create_group("BECKE")
-  h5.h5_write(becke_g, 'r_grid', r_grid)
-  h5.h5_write(becke_g, 'weight', becke_weights)
-  h5.h5_write(becke_g, 'number_of_rpoints', np.int32(becke_weights.shape[0]) )
-
-  scf_g = g.create_group("SCF")
-  h5.h5_write(scf_g, 'ovlp', S[:,:,:nbnd_out,:nbnd_out])
-  h5.h5_write(scf_g, 'H0', H0[:,:,:nbnd_out,:nbnd_out])
-  h5.h5_write(scf_g, 'Fock', F[:,:,:nbnd_out,:nbnd_out])
-  h5.h5_write(scf_g, 'dm', dm[:,:,:nbnd_out,:nbnd_out])
-  h5.h5_write(scf_g, 'mo_coeff', mo_coeff[:,:,:nbnd_out,:nbnd_out])
-  h5.h5_write(scf_g, 'eigval', mo_energy[:,:,:nbnd_out])
-  h5.h5_write(scf_g, 'occ', mo_occ[:,:,:nbnd_out])
-  del f
+    g.create_group("SCF")
+    scf_g = g["SCF"]
+    scf_g['ovlp'] = S[:,:,:nbnd_out,:nbnd_out]
+    scf_g['H0'] = H0[:,:,:nbnd_out,:nbnd_out]
+    scf_g['Fock'] = F[:,:,:nbnd_out,:nbnd_out]
+    scf_g['dm'] = dm[:,:,:nbnd_out,:nbnd_out]
+    scf_g['mo_coeff'] = mo_coeff[:,:,:nbnd_out,:nbnd_out]
+    scf_g['eigval'] = mo_energy[:,:,:nbnd_out]
+    scf_g['occ'] = mo_occ[:,:,:nbnd_out]
 
   dump_orb(outdir+"/Orb_r", Orb_r[:,:nbnd_out])
 
@@ -317,10 +314,8 @@ def dump_orb(outdir, Orb_G):
 
   nsk, nao, nG = Orb_G.shape[:3]
   for isk in range(nsk):
-    f = h5.File(outdir+"/Orb_"+str(isk)+".h5", 'w')
-    grp = h5.Group(f)
-    h5.h5_write(grp, "Orb_"+str(isk), Orb_G[isk])
-    del f
+    with h5.HDFArchive(outdir+"/Orb_"+str(isk)+".h5", 'w') as grp:
+      grp["Orb_"+str(isk)] = Orb_G[isk]
 
 
 

--- a/src/scripts/read_last_it.py
+++ b/src/scripts/read_last_it.py
@@ -76,10 +76,5 @@ def copy_all_and_last_iters(g_in, g_out, keep_first_iter=False):
                 raise ValueError("The key final_iter is not found!")
 
 
-g_in = h5.HDFArchive(finput, 'r')
-g_out = h5.HDFArchive(foutput, 'w')
-
-copy_all_and_last_iters(g_in, g_out, keep_first_it)
-
-del g_out
-del g_in
+with h5.HDFArchive(finput, 'r') as g_in, h5.HDFArchive(foutput, 'w') as g_out:
+    copy_all_and_last_iters(g_in, g_out, keep_first_it)

--- a/src/scripts/read_last_it.py
+++ b/src/scripts/read_last_it.py
@@ -18,7 +18,7 @@ limitations under the License.
 ==========================================================================
 """
 
-import h5._h5py as h5
+import h5
 import argparse
 
 # Usage: 
@@ -35,10 +35,6 @@ finput = args.inp
 foutput = args.out
 keep_first_it = args.keep_first_it
 
-h_in = h5.File(finput, 'r')
-h_out = h5.File(foutput, 'w')
-
-
 def recursive_copy(g_in, g_out):
     for k in g_in.keys():
         copy_from_key(g_in, g_out, k)
@@ -46,15 +42,15 @@ def recursive_copy(g_in, g_out):
 
 def copy_from_key(g_in, g_out, k):
     # recursively copy subgroups without datasets
-    if g_in.has_subgroup(k):
+    if g_in.is_group(k):
         g_out.create_group(k)
-        gg_in = g_in.open_group(k)
-        gg_out = g_out.open_group(k)
+        gg_in = g_in.get_raw(k)
+        gg_out = g_out.get_raw(k)
         recursive_copy(gg_in, gg_out)
         # copy datasets (do no occur in the current format)
     else:
-        if g_in.has_dataset(k):
-            h5.h5_write(g_out, k, h5.h5_read(g_in, k))
+        if g_in.is_data(k):
+            g_out[k] = g_in.get_raw(k)
         else:
             raise ValueError("The key is neither group nor dataset")
 
@@ -64,26 +60,26 @@ def copy_all_and_last_iters(g_in, g_out, keep_first_iter=False):
         if k not in {'scf', 'embed'}:
             copy_from_key(g_in, g_out, k)
         else:
-            gg_in = g_in.open_group(k)
+            gg_in = g_in.get_raw(k)
             g_out.create_group(k)
-            gg_out = g_out.open_group(k)
-            if gg_in.has_dataset('final_iter'):
-                final_iter = h5.h5_read(gg_in, 'final_iter')
-                h5.h5_write(gg_out, 'final_iter', final_iter)
+            gg_out = g_out.get_raw(k)
+            if gg_in.is_data('final_iter'):
+                final_iter = gg_in.get_raw('final_iter')
+                gg_out['final_iter'] = final_iter
                 # copy the last iteration
-                if gg_in.has_subgroup('iter'+str(final_iter)):
+                if gg_in.is_group('iter'+str(final_iter)):
                     copy_from_key(gg_in, gg_out, 'iter'+str(final_iter))
                 if keep_first_iter and final_iter!=1:
-                    if gg_in.has_subgroup('iter1'):
+                    if gg_in.is_group('iter1'):
                         copy_from_key(gg_in, gg_out, 'iter1')
             else:
                 raise ValueError("The key final_iter is not found!")
-                
 
-g_in = h5.Group(h_in)
-g_out = h5.Group(h_out)
+
+g_in = h5.HDFArchive(finput, 'r')
+g_out = h5.HDFArchive(foutput, 'w')
 
 copy_all_and_last_iters(g_in, g_out, keep_first_it)
 
-del h_out
-del h_in
+del g_out
+del g_in


### PR DESCRIPTION
1. improve `dmft` submodule input handling
2. guard against non-existing `results` data group in `coqui.dmft.plot_edmft_convergence`
3. Update h5 usage from `h5._h5py` to `HDFArchive`  
4. Fix mpi broadcast bug in wannier interpolation