### PR TITLE
workaround for "roundup" macro conflict bug in slate

### DIFF
--- a/src/numerics/distributed_array/detail/slate_aux.hpp
+++ b/src/numerics/distributed_array/detail/slate_aux.hpp
@@ -32,8 +32,8 @@
 #include "numerics/distributed_array/detail/concepts.hpp"
 #include "numerics/distributed_array/detail/ops_aux.hpp"
 #if defined(ENABLE_SLATE)
-#include "slate/slate.hh"
-#endif 
+#include "numerics/distributed_array/detail/slate_include.hpp"
+#endif
 #if defined(ENABLE_CUDA)
 #include "cuda_runtime.h"
 #endif

--- a/src/numerics/distributed_array/detail/slate_include.hpp
+++ b/src/numerics/distributed_array/detail/slate_include.hpp
@@ -1,0 +1,15 @@
+#ifndef NUMERICS_DISTRIBUTED_ARRAY_SLATE_INCLUDE_HPP
+#define NUMERICS_DISTRIBUTED_ARRAY_SLATE_INCLUDE_HPP
+
+/*
+ * SLATE's `roundup` function can conflict with an OS-provided `roundup` macro,
+ * so we explicitly undefine the macro here just in case.
+ * See https://github.com/icl-utk-edu/slate/issues/227.
+ */
+#ifdef roundup
+#undef roundup
+#endif
+
+#include "slate/slate.hh"
+
+#endif // NUMERICS_DISTRIBUTED_ARRAY_SLATE_INCLUDE_HPP

--- a/src/numerics/distributed_array/slate_ops.hpp
+++ b/src/numerics/distributed_array/slate_ops.hpp
@@ -34,9 +34,6 @@
 #include "numerics/distributed_array/ops.hpp"
 #include "numerics/distributed_array/detail/ops_aux.hpp"
 #include "numerics/distributed_array/detail/slate_aux.hpp"
-#if defined(ENABLE_SLATE)
-#include "slate/slate.hh"
-#endif 
 
 namespace math::nda::slate_ops
 {

--- a/src/numerics/slate/tests/test_slate.cpp
+++ b/src/numerics/slate/tests/test_slate.cpp
@@ -33,7 +33,7 @@
 
 #include "utilities/test_common.hpp"
 
-#include "slate/slate.hh"
+#include "numerics/distributed_array/detail/slate_include.hpp"
 
 namespace bdft_tests
 {


### PR DESCRIPTION
The roundup function implemented in [slate/include/internal/util.hh](https://github.com/icl-utk-edu/slate/blob/ded152906b0c54ec97abdf26e1c36422fb9c36be/include/slate/internal/util.hh#L116) triggers a compilation error whenever the operating-system macro with the same name, roundup(x, y), is defined and therefore conflicts with SLATE's implementation.

Here, we explicitly undefines  the `roundup` macro locally to avoid conflicts. 