### PR TITLE
Build fft_lib as shared under python support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,6 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 ######################################################################
 option(ENABLE_ROCM " Build device code with ROCM backend" OFF)
 option(ENABLE_OPENMP " Build device code with OPENMP backend" OFF)
-option(ENABLE_FFTW "Build using FFTW3 library." ON)
 option(ENABLE_HEFFTE "Build using heFFTe library." OFF)
 option(ENABLE_SLATE "Build using Slate library." ON)
 option(ENABLE_CUTENSOR "Build using cutensor library. Must set CUTENSOR_ROOT" OFF)
@@ -256,12 +255,33 @@ cmake_print_properties(TARGETS MPI::MPI_CXX PROPERTIES INTERFACE_LINK_LIBRARIES 
 #cmake_print_properties(TARGETS LAPACK::LAPACK PROPERTIES INTERFACE_LINK_LIBRARIES)
 
 ######################################################################
-# FFTW: not using MKL's FFTW yet, figure out how if requested 
+# FFT backend selection (FFTW3 real vs MKL's FFTW3 interface)
 ######################################################################
-if(ENABLE_FFTW)
-  find_package(FFTW REQUIRED DOUBLE_OPENMP_LIB)
-  add_compile_definitions(ENABLE_FFTW)
+
+set(COQUI_FFT_BACKEND FFTW CACHE STRING "FFT backend: FFTW (real FFTW3) or MKL")
+set_property(CACHE COQUI_FFT_BACKEND PROPERTY STRINGS FFTW MKL)
+
+# Disable ENABLE_FFTW from users; use COQUI_FFT_BACKEND instead.  
+if(DEFINED ENABLE_FFTW)
+  message(FATAL_ERROR "ENABLE_FFTW is removed; use -DCOQUI_FFT_BACKEND=FFTW or =MKL.")
 endif()
+
+if(COQUI_FFT_BACKEND STREQUAL "FFTW")
+  find_package(FFTW REQUIRED DOUBLE_OPENMP_LIB)
+  message(STATUS "FFT backend: FFTW3 (real)  [${FFTW_DOUBLE_LIB}]")
+elseif(COQUI_FFT_BACKEND STREQUAL "MKL")
+  set(MKL_FFTW_INCLUDE_DIR "$ENV{MKLROOT}/include/fftw")
+  if(NOT EXISTS "${MKL_FFTW_INCLUDE_DIR}/fftw3.h")
+    message(FATAL_ERROR "COQUI_FFT_BACKEND=MKL but ${MKL_FFTW_INCLUDE_DIR}/fftw3.h "
+                        "was not found. Set MKLROOT.")
+  endif()
+  message(STATUS "FFT backend: MKL FFTW3 interface  [$ENV{MKLROOT}]")
+else()
+  message(FATAL_ERROR "Invalid COQUI_FFT_BACKEND='${COQUI_FFT_BACKEND}' (expected FFTW or MKL).")
+endif()
+
+# fftw-API CPU backend is always compiled in (both backends use fftw_*).
+add_compile_definitions(ENABLE_FFTW)
 
 ######################################################################
 # HEFFTE: Highly Efficient FFT for Exascale

--- a/src/numerics/fft/CMakeLists.txt
+++ b/src/numerics/fft/CMakeLists.txt
@@ -19,8 +19,16 @@ if(ENABLE_CUDA)
 endif()
 
 
-add_library(fft_lib ${fft_src})
-target_link_libraries(fft_lib PUBLIC utils nda_c) 
+# Shared under Python so fftw.cpp lives in one libfft_lib.so: as a static
+# archive it is duplicated per c2py module and (under RTLD_LOCAL) can bind
+# fftw_* to MKL's shim in one module and real FFTW3 in another -> plan/exec
+# mismatch -> crash. Gated on COQUI_PYTHON_SUPPORT like io_lib (see 56645d9).
+if(COQUI_PYTHON_SUPPORT)
+  add_library(fft_lib SHARED ${fft_src})
+else()
+  add_library(fft_lib ${fft_src})
+endif()
+target_link_libraries(fft_lib PUBLIC utils nda_c)
 if(ENABLE_FFTW)
   target_link_libraries(fft_lib PUBLIC FFTW::Double) 
 endif()

--- a/src/numerics/fft/CMakeLists.txt
+++ b/src/numerics/fft/CMakeLists.txt
@@ -2,14 +2,8 @@
 #//////////////////////////////////////////////////////////////////////////////////////
 
 set(fft_src
+     fftw.cpp
    )
-
-if(ENABLE_FFTW)
-  set(fft_src 
-       ${fft_src}
-       fftw.cpp 
-     )
-endif()
 
 if(ENABLE_CUDA)
   set(fft_src 
@@ -28,9 +22,13 @@ if(COQUI_PYTHON_SUPPORT)
 else()
   add_library(fft_lib ${fft_src})
 endif()
-target_link_libraries(fft_lib PUBLIC utils nda_c)
-if(ENABLE_FFTW)
-  target_link_libraries(fft_lib PUBLIC FFTW::Double) 
+if(COQUI_FFT_BACKEND STREQUAL "FFTW")
+  # List FFTW::Double first so libfftw3 precedes MKL in the dynamical linking search order. 
+  # FIXME Technically, it does not guarantee mkl's fftw api will not be linked first... 
+  target_link_libraries(fft_lib PUBLIC FFTW::Double utils nda_c)
+else() # MKL
+  target_link_libraries(fft_lib PUBLIC utils nda_c)  # fftw_* resolves to MKL (only provider)
+  target_include_directories(fft_lib PUBLIC ${MKL_FFTW_INCLUDE_DIR})
 endif()
 if(ENABLE_CUDA)
   target_link_libraries(fft_lib PUBLIC CUDA::cufft) 


### PR DESCRIPTION
### Problem
`make_thc_coulomb` segfaults from Python when both FFTW and MKL are loaded.

### Cause
`fft_lib` is a static archive, so `fftw.cpp` (the only `fftw_*` caller) is copied
into every c2py module. Python loads modules with `RTLD_LOCAL`, so each resolves
`fftw_*` in its own `DT_NEEDED`; since MKL (via SLATE) also exports the FFTW3 API,
some modules bind to MKL's shim and others to real FFTW3. A plan built by one and
executed by the other has an incompatible layout → crash. (Single C++ executables
have one namespace, so they never crash — this is Python-only.)

### Fix
Build `fft_lib` as a shared library so `fftw.cpp` lives in one `libfft_lib.so`, following the pattern for `io_lib` in commit 56645d9.