### PR TITLE
Fix the DIIS pseudoinverse eigenvalue threshold in diis_alg::compute_coefs_c1

### DIFF
--- a/src/numerics/iter_scf/diis/diis_alg.hpp
+++ b/src/numerics/iter_scf/diis/diis_alg.hpp
@@ -390,17 +390,18 @@ private:
         Binv() = 0;
         eig_inv() = 0;
 
+        auto eig_abs = nda::map([](double x) { return std::abs(x); })(eig);
         double eig_max = nda::max_element(eig);
-        double eig_min = nda::min_element(eig);
-        double cond = eig_max / eig_min;
+        double cond = nda::max_element(eig_abs) / nda::min_element(eig_abs);
 
         const double eig_thresh = 1E-12;
 
         app_log(2, diis_str + "Condition number of B: {}", cond);
 
-        for (auto i : nda::range(0, eig.size())) { 
-            if(eig(i)*cond > eig_thresh) {
-                eig_inv(i,i) = 1.0/(eig(i)); 
+        // Pseudoinverse: only keep positive eigenvalues above eig_thresh*eig_max.
+        for (auto i : nda::range(0, eig.size())) {
+            if(eig(i) > eig_thresh*eig_max) {
+                eig_inv(i,i) = 1.0/(eig(i));
             }
         }
 

--- a/src/numerics/iter_scf/diis/diis_alg.hpp
+++ b/src/numerics/iter_scf/diis/diis_alg.hpp
@@ -25,6 +25,7 @@
 #define DIIS_DEBUG 0
 
 #include <complex>
+#include <sstream>
 #include "nda/linalg/dot.hpp"
 #include <nda/linalg/eigenelements.hpp>
 #include "diis_residual.h"
@@ -96,23 +97,26 @@ private:
     std::string diis_str = "DIIS: ";
 
     void print_B() {
-        std::cout << diis_str << "error overlaps B:" << std::endl;
-        std::cout << std::setprecision(10);
+        std::ostringstream os;
+        os << diis_str << "error overlaps B:" << std::endl;
+        os << std::setprecision(10);
         for(auto i : nda::range(0, m_B.shape()[0])) {
-            for(auto j : nda::range(0, m_B.shape()[1])) 
-                std::cout << m_B(i,j) << " ";
+            for(auto j : nda::range(0, m_B.shape()[1]))
+                os << m_B(i,j) << " ";
 
-            std::cout << std::endl;;
+            os << std::endl;
         }
+        app_log(3, "{}", os.str());
     }
 
     void print_C() {
-        std::cout << diis_str << "Extrapolation coefficients:" << std::endl;
-        std::cout << std::setprecision(10);
+        std::ostringstream os;
+        os << diis_str << "Extrapolation coefficients:" << std::endl;
+        os << std::setprecision(10);
         for(auto i : nda::range(0, m_B.shape()[0]))
-                std::cout << m_C(i) << " ";
+                os << m_C(i) << " ";
 
-            std::cout << std::endl;;
+        app_log(3, "{}", os.str());
     }
 
 public:
@@ -411,8 +415,8 @@ private:
         nda::array<double, 1> x(B.shape()[1]); 
         nda::blas::gemv(1.0, Binv, bb, 0.0, x);
         
-        std::complex<double> sum = std::accumulate(x.begin(), x.end(), 0.0);
-        m_C = make_regular(nda::real(x / sum));
+        double sum = std::accumulate(x.begin(), x.end(), 0.0);
+        m_C = make_regular(x / sum);
      }
 
 


### PR DESCRIPTION
### Summary
* Fix bug in pseudoinverse of DIIS overlap
* Print DIIS information through the logger instead of directly to stdout

## Problem

`diis_alg::compute_coefs_c1` builds the DIIS coefficients as `c = B⁻¹1 / (1ᵀB⁻¹1)` through a
thresholded pseudoinverse of the residual-overlap matrix `B`. The pseudoinverse was implemented
incorrectly: the threshold never fired, so `B` was always inverted in full, including its
numerically-null directions.

## Fix

[`src/numerics/iter_scf/diis/diis_alg.hpp`](https://github.com/AbInitioQHub/coqui/blob/3f807e4/src/numerics/iter_scf/diis/diis_alg.hpp#L393-L405)

- before: `eig(i)*cond > 1e-12`, i.e. `λᵢ > 1e-12 · λ_min/λ_max`
- after: `eig(i) > 1e-12*eig_max`, i.e. `λᵢ > 1e-12 · λ_max`

Two defects, one line:

1. **The cutoff never truncated.** `1e-12 · λ_min/λ_max ≤ 1e-12 · λ_min < λᵢ` for every
   eigenvalue, so the `else` branch was unreachable for positive-definite `B`. It also *loosened*
   as `B` grew worse conditioned, which is backwards.
2. **A negative `λ_min` inverted the test.** `B` is a Gram matrix of residuals — PSD in exact
   arithmetic, but roundoff on a near-dependent subspace routinely produces a small negative
   eigenvalue. Then `cond < 0`, every positive `λᵢ` fails, and only the noise directions are kept
   and inverted. The new form needs no sign handling: `1e-12 · λ_max > 0` rejects them.

Also report `cond` as `max|λ| / min|λ|` (the condition number of a symmetric matrix) rather than
`λ_max/λ_min`. Diagnostic only — `cond` no longer enters the filter.

Second commit, unrelated cleanups: `print_B`/`print_C` emit through `app_log(3)` rather than writing
to `std::cout` at every verbosity, and `sum` in the coefficient normalization becomes a `double`
since `x` is real.

## Test

**CI suite** — `ctest`: 26/26 pass, including `test_methods_scf`
(`qp_iterative_solver_diis_vs_damping`, `dyson_scf_gw_diis_vs_damping`; 6-vector subspace, qe_lih222
and pyscf_si222 against reference energies). These fixtures stay well-conditioned, so the
coefficients are unchanged — they guard against regression, they do not exercise the bug.

**Manual check, not in CI** — the old and new criteria reimplemented outside CoQuí and applied to
`B` with spectrum `{λ_min, 1e-3, 1e-2, 3e-2, 1e-1, 1}`, one collapsed direction. `cᵀBc` is the
squared predicted error the code already logs:

| | modes kept | `cᵀBc` |
|---|---|---|
| before, λ_min = +1e-13 | 6/6 | 6.5e-14 — fake, rides the null direction |
| after, λ_min = +1e-13 | 5/6 | 9.1e-4 |
| before, λ_min = −1e-13 | 1/6 | **−6.5e-14** — negative squared norm |
| after, λ_min = −1e-13 | 5/6 | 9.1e-4 |

`c` itself stays O(1) rather than blowing up: the null direction cancels between `B⁻¹1` and
`1ᵀB⁻¹1`, leaving `c` equal to the noise eigenvector normalized to sum 1. So the symptom is a
silently arbitrary extrapolation direction, not obviously wild coefficients — a negative
"Squared predicted error of extrapolated vector" in a log is the visible tell.
