### PR TITLE
Add detailed progress diagnostics for GW Sigma and P calculations

### DIFF
--- a/src/methods/GW/gw_t.cpp
+++ b/src/methods/GW/gw_t.cpp
@@ -43,22 +43,9 @@ namespace methods {
        _Timer() {}
 
     void gw_t::print_thc_gw_timers() {
-      app_log(2, "\n  THC-GW timers");
-      app_log(2, "  -------------");
+      app_log(2, "\n  THC-GW self-energy timers");
+      app_log(2, "  -------------------------");
       app_log(2, "    Total:                   {0:.3f} sec", _Timer.elapsed("TOTAL"));
-      if (_Timer.elapsed("EVALUATE_PI_K") > 0.0) {
-        app_log(2, "    Evaluate Pi (k):         {0:.3f} sec", _Timer.elapsed("EVALUATE_PI_K"));
-        app_log(2, "      - Alloc:               {0:.3f} sec", _Timer.elapsed("PI_ALLOC_K"));
-        app_log(2, "      - Gij -> Guv:          {0:.3f} sec", _Timer.elapsed("PI_PRIM_TO_AUX"));
-        app_log(2, "      - Hadamard product:    {0:.3f} sec", _Timer.elapsed("PI_HADPROD_K"));
-      } else if (_Timer.elapsed("EVALUATE_PI_R") > 0.0) {
-        app_log(2, "    Evaluate Pi (R):         {0:.3f} sec", _Timer.elapsed("EVALUATE_PI_R"));
-        app_log(2, "      - Alloc:               {0:.3f} sec", _Timer.elapsed("PI_ALLOC_R"));
-        app_log(2, "      - Gij -> Guv:          {0:.3f} sec", _Timer.elapsed("PI_PRIM_TO_AUX"));
-        app_log(2, "      - FT:                  {0:.3f} sec", _Timer.elapsed("PI_FT_R"));
-        app_log(2, "      - Hadamard product:    {0:.3f} sec", _Timer.elapsed("PI_HADPROD_R"));
-      }
-      app_log(2, "    Evaluate W:              {0:.3f} sec", _Timer.elapsed("EVALUATE_W"));
       if (_Timer.elapsed("EVALUATE_SIGMA_K") > 0.0) {
         app_log(2, "    Evaluate Sigma (K):      {0:.3f} sec", _Timer.elapsed("EVALUATE_SIGMA_K"));
         app_log(2, "      - Alloc:               {0:.3f} sec", _Timer.elapsed("SIGMA_ALLOC_K"));
@@ -74,9 +61,8 @@ namespace methods {
         app_log(2, "      - Hadamard product:    {0:.3f} sec", _Timer.elapsed("SIGMA_HADPROD_R"));
         app_log(2, "      - Sigma_uv -> Sigma_ij {0:.3f} sec", _Timer.elapsed("SIGMA_AUX_TO_PRIM"));
       }
-      app_log(2, "    Imaginary FT tau->w:     {0:.3f} sec", _Timer.elapsed("IMAG_FT_TtoW"));
-      app_log(2, "    Imaginary FT w->tau:     {0:.3f} sec", _Timer.elapsed("IMAG_FT_WtoT"));
-      app_log(2, "      - FT_REDISTRIBUTE:     {0:.3f} sec\n", _Timer.elapsed("FT_REDISTRIBUTE"));
+      app_log(2, "");
+      app_log_flush();
     }
 
     void gw_t::print_thc_rpa_timers() {
@@ -128,4 +114,3 @@ namespace methods {
 
   } // solvers
 } // methods
-

--- a/src/methods/GW/thc_gw.cpp
+++ b/src/methods/GW/thc_gw.cpp
@@ -94,6 +94,7 @@ namespace methods {
         _Timer.add(v);
       }
 
+      _Timer.reset_all();
       _Timer.start("TOTAL");
       thc_gw_Xqindep(mb_state.sG_tskij.value().local(), mb_state.sSigma_tskij.value(), thc,
                      mb_state.dW_qtPQ.value(), mb_state.eps_inv_head.value());
@@ -152,6 +153,7 @@ namespace methods {
         _Timer.add(v);
       }
 
+      _Timer.reset_all();
       _Timer.start("TOTAL");
       sSigma_tskij.set_zero();
       if (thc.thc_X_type() == "q_dep") {

--- a/src/methods/GW/thc_gw.icc
+++ b/src/methods/GW/thc_gw.icc
@@ -1,6 +1,8 @@
 #ifndef COQUI_THC_GW_ICC
 #define COQUI_THC_GW_ICC
 
+#include <chrono>
+
 #include "mpi3/communicator.hpp"
 #include "nda/nda.hpp"
 #include "nda/blas.hpp"
@@ -29,7 +31,19 @@ namespace methods {
                               const nda::MemoryArrayOfRank<1> auto &eps_inv_head) {
       eval_Sigma_all(G_tskij, dW_qtPQ, sSigma_tskij, thc,
                      (thc.MF()->nqpts() == thc.MF()->nqpts_ibz()? "R" : "k"));
+      auto div_start = std::chrono::steady_clock::now();
+      if (_div_treatment == "ignore_g0") {
+        app_log(2, "    - Sigma divergence correction: skipped (ignore_g0)");
+      } else {
+        app_log(2, "    - Sigma divergence correction: started");
+      }
+      app_log_flush();
       Sigma_div_correction(sSigma_tskij, G_tskij, thc, eps_inv_head);
+      double div_elapsed = std::chrono::duration<double>(
+          std::chrono::steady_clock::now() - div_start).count();
+      if (_div_treatment != "ignore_g0")
+        app_log(2, "    - Sigma divergence correction: completed in {:.1f} s", div_elapsed);
+      app_log_flush();
     }
 
     template<nda::MemoryArray Array_primary_t, nda::MemoryArray Array_aux_t, typename communicator_t>
@@ -72,6 +86,22 @@ namespace methods {
                                THC_ERI auto &thc,
                                bool minus_t) {
       _Timer.start("EVALUATE_SIGMA_R");
+      char const* tau_branch = minus_t? "negative tau" : "positive tau";
+      auto sigma_start = std::chrono::steady_clock::now();
+      app_log(2, "    - Sigma [{}] R-space branch: started", tau_branch);
+      app_log_flush();
+      auto stage_start = sigma_start;
+      auto start_stage = [&](char const* stage) {
+        app_log(2, "      - Sigma [{}] {}: started", tau_branch, stage);
+        app_log_flush();
+        stage_start = std::chrono::steady_clock::now();
+      };
+      auto finish_stage = [&](char const* stage) {
+        double elapsed = std::chrono::duration<double>(
+            std::chrono::steady_clock::now() - stage_start).count();
+        app_log(2, "      - Sigma [{}] {}: completed in {:.1f} s", tau_branch, stage, elapsed);
+        app_log_flush();
+      };
       auto MF = thc.MF();
       auto mpi = thc.mpi();
       utils::check(MF->nqpts() == MF->nqpts_ibz() and MF->nqpts() == MF->nkpts(),
@@ -98,6 +128,7 @@ namespace methods {
             mpi->comm, {tpools, 1, qpools, np_P, np_Q}, {nt_half, ns, nkpts, NP, NQ}, {bsize[1], 1, bsize[0], bsize[2], bsize[3]});
         _Timer.stop("SIGMA_ALLOC_R");
 
+        start_stage("primary -> auxiliary");
         _Timer.start("SIGMA_PRIM_TO_AUX");
         if (minus_t) {
           // G_ij(t) -> G_ij(beta-t)
@@ -118,6 +149,7 @@ namespace methods {
                                           MF->kp_to_ibz(), MF->kp_trev());
         }
         _Timer.stop("SIGMA_PRIM_TO_AUX");
+        finish_stage("primary -> auxiliary");
 
         _Timer.start("SIGMA_ALLOC_R");
         auto G_tskPQ = dG_tskPQ.local();
@@ -134,6 +166,7 @@ namespace methods {
       math::shm::shared_array<nda::array_view<ComplexType,2>> sf_Rk(*mpi, {nkpts,nkpts});
 
       if (nkpts != 1) {
+        start_stage("FFT k/q -> R");
         _Timer.start("SIGMA_FT_R");
         auto f_Rk = sf_Rk.local();
         utils::k_to_R_coefficients(mpi->comm, nda::range(nkpts), MF->kpts(), MF->lattv(), MF->kp_grid(), sf_Rk);
@@ -151,11 +184,16 @@ namespace methods {
           WR_2D = R_buffer;
         }
         _Timer.stop("SIGMA_FT_R");
+        finish_stage("FFT k/q -> R");
+      } else {
+        app_log(2, "      - Sigma [{}] FFT k/q -> R: skipped (single k-point)", tau_branch);
+        app_log_flush();
       }
 
       // Sigma_R = G_R * W_R
       auto dSigma_sktPQ = make_distributed_array<local_Array_5D_t>(
           mpi->comm, {1, qpools, tpools, np_P, np_Q}, {ns, nkpts, nt_half, NP, NQ}, {1, bsize[0], bsize[1], bsize[2], bsize[3]});
+      start_stage("Hadamard G * W");
       _Timer.start("SIGMA_HADPROD_R");
       auto had_prod2 = nda::map([](ComplexType x, ComplexType y) { return -1.0 * (x * y) ; });
       auto W_RtPQ = dW_qtPQ.local();
@@ -165,10 +203,12 @@ namespace methods {
         Sigma_RtPQ = had_prod2(G_RtPQ, W_RtPQ);
       }
       _Timer.stop("SIGMA_HADPROD_R");
+      finish_stage("Hadamard G * W");
       dG_sRtPQ.reset();
 
       if (nkpts != 1) {
         // FT back to q-space
+        start_stage("FFT R -> k/q");
         auto f_kR = sf_Rk.local();
         utils::R_to_k_coefficients(mpi->comm, nda::range(nkpts), MF->kpts(), MF->lattv(), MF->kp_grid(), sf_Rk);
 
@@ -187,6 +227,10 @@ namespace methods {
           WR_2D = buffer;
         }
         _Timer.stop("SIGMA_FT_R");
+        finish_stage("FFT R -> k/q");
+      } else {
+        app_log(2, "      - Sigma [{}] FFT R -> k/q: skipped (single k-point)", tau_branch);
+        app_log_flush();
       }
 
       _Timer.start("SIGMA_ALLOC_R");
@@ -207,8 +251,14 @@ namespace methods {
 
       // TODO redistribute over (t, k, P, Q) to minimize MPI along (P, Q)-axes
 
+      start_stage("auxiliary -> primary");
       setup_Sigma_primary(dSigma_tskPQ, sSigma_tskij, thc, MF->ks_to_k(0), minus_t);
+      finish_stage("auxiliary -> primary");
       _Timer.stop("EVALUATE_SIGMA_R");
+      double sigma_elapsed = std::chrono::duration<double>(
+          std::chrono::steady_clock::now() - sigma_start).count();
+      app_log(2, "    - Sigma [{}] R-space branch: completed in {:.1f} s", tau_branch, sigma_elapsed);
+      app_log_flush();
     }
 
     template<nda::MemoryArray Array_5D_t, nda::MemoryArray Array_4D_t, typename communicator_t>
@@ -223,6 +273,10 @@ namespace methods {
       decltype(nda::range::all) all;
 
       _Timer.start("EVALUATE_SIGMA_K");
+      char const* tau_branch = minus_t? "negative tau" : "positive tau";
+      auto sigma_start = std::chrono::steady_clock::now();
+      app_log(2, "    - Sigma [{}] k-space branch: started", tau_branch);
+      app_log_flush();
       auto MF = thc.MF();
       long nbnd = MF->nbnd();
       long nkpts = MF->nkpts();
@@ -274,6 +328,12 @@ namespace methods {
       nda::array<ComplexType,2> Tm(nbnd,nbnd);
       _Timer.stop("SIGMA_ALLOC_K");
 
+      size_t nt_loc_count = static_cast<size_t>(nt_loc);
+      size_t report_stride = (nt_loc_count > 0)? (nt_loc_count + 9) / 10 : 1;
+      auto progress_start = std::chrono::steady_clock::now();
+      app_log(2, "      - Sigma [{}] local tau shard: origin {}, {} slice(s)",
+              tau_branch, t_origin, nt_loc_count);
+      app_log_flush();
       sSigma_tskij.win().fence();
       for (size_t it=0; it<nt_loc; it++) {
         long it_global = (minus_t)? nt-(it+t_origin)-1 : it+t_origin;
@@ -320,6 +380,17 @@ namespace methods {
           _Timer.stop("SIGMA_MULTIPLY_DMAT_K");
           sSigma_tskij.node_comm()->barrier();
         } // isym
+        size_t done = it + 1;
+        if (done == 1 or done == nt_loc_count or done % report_stride == 0) {
+          double elapsed = std::chrono::duration<double>(
+              std::chrono::steady_clock::now() - progress_start).count();
+          double eta = elapsed / static_cast<double>(done) * static_cast<double>(nt_loc_count - done);
+          double percent = 100.0 * static_cast<double>(done) / static_cast<double>(nt_loc_count);
+          app_log(2, "      - Sigma [{}] local tau slices: {}/{} ({:.0f}%), "
+                     "elapsed {:.1f} s, ETA {:.1f} s",
+                  tau_branch, done, nt_loc_count, percent, elapsed, eta);
+          app_log_flush();
+        }
       } // it
       // dummy loops to avoid dead blocks in case nt_loc are not consistent in different processors
       if (nt_loc < nt_loc_max) {
@@ -335,6 +406,10 @@ namespace methods {
       } // ( nt_loc < nt_loc_max )
       sSigma_tskij.win().fence();
       _Timer.stop("EVALUATE_SIGMA_K");
+      double sigma_elapsed = std::chrono::duration<double>(
+          std::chrono::steady_clock::now() - sigma_start).count();
+      app_log(2, "    - Sigma [{}] k-space branch: completed in {:.1f} s", tau_branch, sigma_elapsed);
+      app_log_flush();
     }
 
     template<nda::MemoryArray Array_4D_t, typename communicator_t>

--- a/src/methods/scr_coulomb/rpa_pi.icc
+++ b/src/methods/scr_coulomb/rpa_pi.icc
@@ -1,6 +1,9 @@
 #ifndef COQUI_RPA_PI_ICC
 #define COQUI_RPA_PI_ICC
 
+#include <algorithm>
+#include <chrono>
+
 #include "configuration.hpp"
 #include "nda/nda.hpp"
 #include "nda/h5.hpp"
@@ -62,21 +65,37 @@ namespace solvers {
                "    - processor grid for Pi: (t, q, P, Q) = ({}, {}, {}, {})\n",
                ntpools, 1, np_P, np_Q);
 
+    using progress_clock = std::chrono::steady_clock;
+    auto setup_start = progress_clock::now();
+    app_log(2, "    - [P] setup output distribution: started");
+    app_log_flush();
     _Timer.start("PI_ALLOC_R");
     auto dPi_tqPQ = make_distributed_array<local_Array_4D_t>(
         mpi->comm, {ntpools, 1, np_P, np_Q}, {nt_half, nqpts_ibz, Np, Np}, {1, 1, 1, 1});
     auto [t_origin, q_origin, P_origin, Q_origin] = dPi_tqPQ.origin();
     auto [nt_loc, nq_loc, NP_loc, NQ_loc] = dPi_tqPQ.local_shape();
+    app_log(2, "    - [P] setup output distribution: completed in {:.1f} s",
+            std::chrono::duration<double>(progress_clock::now() - setup_start).count());
+    app_log_flush();
 
     // prepare Fourier transform matrices between k-space and R-space
+    setup_start = progress_clock::now();
+    app_log(2, "    - [P] setup Fourier coefficient matrices: started");
+    app_log_flush();
     math::shm::shared_array<nda::array_view<ComplexType,2>> sf_Rk(*mpi, {nkpts,nkpts});
     utils::k_to_R_coefficients(mpi->comm, nda::range(nkpts), MF->kpts(), MF->lattv(), MF->kp_grid(), sf_Rk);
     auto f_Rk = sf_Rk.local();
     math::shm::shared_array<nda::array_view<ComplexType,2>> sf_qR(*mpi,{nqpts_ibz,nkpts});
     utils::R_to_k_coefficients(mpi->comm, nda::range(nkpts), MF->Qpts_ibz(), MF->lattv(), MF->kp_grid(), sf_qR);
     auto f_qR = sf_qR.local();
+    app_log(2, "    - [P] setup Fourier coefficient matrices: completed in {:.1f} s",
+            std::chrono::duration<double>(progress_clock::now() - setup_start).count());
+    app_log_flush();
 
     // Setup t_intra_comm
+    setup_start = progress_clock::now();
+    app_log(2, "    - [P] setup auxiliary work buffers: started");
+    app_log_flush();
     mpi3::communicator t_intra_comm = mpi->comm.split(t_origin, mpi->comm.rank());
     utils::check(t_intra_comm.size()==np_P*np_Q, "t_intra_comm.size() = {} != np_P*np_Q", t_intra_comm.size());
 
@@ -91,6 +110,9 @@ namespace solvers {
     utils::check(dGp_sRPQ.local_shape()[2] == NP_loc, "dGp_sRPQ.local_shape[2] != NP_loc");
     utils::check(dGp_sRPQ.local_shape()[3] == NQ_loc, "dGp_sRPQ.local_shape[3] != NQ_loc");
     _Timer.stop("PI_ALLOC_R");
+    app_log(2, "    - [P] setup auxiliary work buffers: completed in {:.1f} s",
+            std::chrono::duration<double>(progress_clock::now() - setup_start).count());
+    app_log_flush();
 
     auto Pi_tqPQ_loc  = dPi_tqPQ.local();
     auto Gp_sRPQ_loc  = dGp_sRPQ.local();
@@ -98,13 +120,40 @@ namespace solvers {
     auto buf_skPQ_loc = dbuf_skPQ.local();
 
     auto had_prod2 = nda::map([](ComplexType x, ComplexType y) { return (x * y); });
+    auto progress_start = progress_clock::now();
+    const size_t progress_stride = std::max<size_t>(1, (nt_loc + 9) / 10);
+    double prim_to_aux_seconds = 0.0;
+    double unfold_seconds = 0.0;
+    double k_to_R_seconds = 0.0;
+    double hadamard_seconds = 0.0;
+    double R_to_q_seconds = 0.0;
+    auto begin_stage = [&](size_t it, char const *stage) {
+      if (it == 0) {
+        app_log(2, "      - [P] first local tau {}: started", stage);
+        app_log_flush();
+      }
+      return progress_clock::now();
+    };
+    auto finish_stage = [&](size_t it, char const *stage, auto const &start, double &total) {
+      double elapsed = std::chrono::duration<double>(progress_clock::now() - start).count();
+      total += elapsed;
+      if (it == 0) {
+        app_log(2, "      - [P] first local tau {}: completed in {:.1f} s", stage, elapsed);
+        app_log_flush();
+      }
+    };
+    app_log(2, "    - [P] root time-slice shard: global offset {}, {} local slices", t_origin, nt_loc);
+    app_log_flush();
 
     for (size_t it=0; it<nt_loc; it++) {
       // setup Gp
+      auto stage_start = begin_stage(it, "G(+tau) primary -> auxiliary");
       _Timer.start("PI_PRIM_TO_AUX");
       thc_solver_comm::primary_to_aux(0, 0, G_tskij(it+t_origin,nda::ellipsis{}), dbuf_skPQ, thc, MF->kp_to_ibz(), MF->kp_trev());
       //thc_solver_comm::setup_G_thc(it+t_origin, G_tskij, dbuf_skPQ, thc, false,  MF->kp_to_ibz(), MF->kp_trev());
       _Timer.stop("PI_PRIM_TO_AUX");
+      finish_stage(it, "G(+tau) primary -> auxiliary", stage_start, prim_to_aux_seconds);
+      stage_start = begin_stage(it, "G(+tau) symmetry unfold/copy");
       for (size_t ik=0; ik<nkpts; ++ik) {
         if (kp_trev(ik)) {
           Gp_sRPQ_loc(all,ik,all,all) = nda::conj(buf_skPQ_loc(all,kp_trev_pair(ik),all,all));
@@ -112,7 +161,9 @@ namespace solvers {
           Gp_sRPQ_loc(all,ik,all,all) = buf_skPQ_loc(all,ik,all,all);
         }
       }
+      finish_stage(it, "G(+tau) symmetry unfold/copy", stage_start, unfold_seconds);
       if (nkpts!=1) {
+        stage_start = begin_stage(it, "G(+tau) k -> R GEMM");
         _Timer.start("PI_FT_R");
         for (size_t is=0; is<ns; ++is) {
           auto GpR_2D = nda::reshape(Gp_sRPQ_loc(is, nda::ellipsis{}),
@@ -121,14 +172,18 @@ namespace solvers {
           GpR_2D = X_R_PQ;
         }
         _Timer.stop("PI_FT_R");
+        finish_stage(it, "G(+tau) k -> R GEMM", stage_start, k_to_R_seconds);
       }
 
       // setup Gn
+      stage_start = begin_stage(it, "G(-tau) primary -> auxiliary");
       _Timer.start("PI_PRIM_TO_AUX");
       thc_solver_comm::primary_to_aux(0, 0, G_tskij(G_tskij.shape(0)-it-t_origin-1,nda::ellipsis{}),
                                       dbuf_skPQ, thc, MF->kp_to_ibz(), MF->kp_trev());
       //thc_solver_comm::setup_G_thc(it+t_origin, G_tskij, dbuf_skPQ, thc, true, MF->kp_to_ibz(), MF->kp_trev()); // G_PQ(t)
       _Timer.stop("PI_PRIM_TO_AUX");
+      finish_stage(it, "G(-tau) primary -> auxiliary", stage_start, prim_to_aux_seconds);
+      stage_start = begin_stage(it, "G(-tau) symmetry unfold/copy");
       for (size_t ik=0; ik<nkpts; ++ik) {
         if (kp_trev(ik)) {
           Gn_sRPQ_loc(all,ik,all,all) = nda::conj(buf_skPQ_loc(all,kp_trev_pair(ik),all,all));
@@ -136,7 +191,9 @@ namespace solvers {
           Gn_sRPQ_loc(all,ik,all,all) = buf_skPQ_loc(all,ik,all,all);
         }
       }
+      finish_stage(it, "G(-tau) symmetry unfold/copy", stage_start, unfold_seconds);
       if (nkpts!=1) {
+        stage_start = begin_stage(it, "G(-tau) k -> R GEMM");
         _Timer.start("PI_FT_R");
         for (size_t is=0; is<ns; ++is) {
           auto GnR_2D = nda::reshape(Gn_sRPQ_loc(is, nda::ellipsis{}),
@@ -145,9 +202,11 @@ namespace solvers {
           GnR_2D = X_R_PQ;
         }
         _Timer.stop("PI_FT_R");
+        finish_stage(it, "G(-tau) k -> R GEMM", stage_start, k_to_R_seconds);
       }
 
       // Hadamard product
+      stage_start = begin_stage(it, "Hadamard product");
       _Timer.start("PI_HADPROD_R");
       auto GG_RPQ = Gp_sRPQ_loc(0, nda::ellipsis{});
       auto Gn_RPQ = Gn_sRPQ_loc(0, nda::ellipsis{});
@@ -161,21 +220,43 @@ namespace solvers {
       }
       GG_RPQ *= sp_factor;
       _Timer.stop("PI_HADPROD_R");
+      finish_stage(it, "Hadamard product", stage_start, hadamard_seconds);
 
       if (nkpts != 1) {
         // FT back to q-space
+        stage_start = begin_stage(it, "R -> irreducible-q GEMM");
         _Timer.start("PI_FT_R");
         auto Piq_2D = nda::reshape(Pi_tqPQ_loc(it,nda::ellipsis{}),
                                    shape_t<2>{nqpts_ibz, NP_loc*NQ_loc});
         auto GGR_2D = nda::reshape(GG_RPQ, shape_t<2>{nkpts, NP_loc*NQ_loc});
         nda::blas::gemm(f_qR, GGR_2D, Piq_2D);
         _Timer.stop("PI_FT_R");
+        finish_stage(it, "R -> irreducible-q GEMM", stage_start, R_to_q_seconds);
       } else {
         Pi_tqPQ_loc(it,nda::ellipsis{}) = GG_RPQ;
       }
+
+      const size_t done = it + 1;
+      if (done == 1 or done == nt_loc or done % progress_stride == 0) {
+        const double elapsed = std::chrono::duration<double>(progress_clock::now() - progress_start).count();
+        const double eta = (done < nt_loc)? elapsed * double(nt_loc - done) / double(done) : 0.0;
+        app_log(2, "    - [P] root time-slice shard {}/{} ({:.0f}%): elapsed {:.1f} s, ETA {:.1f} s",
+                done, nt_loc, 100.0 * double(done) / double(nt_loc), elapsed, eta);
+        app_log_flush();
+      }
     } // it
+    app_log(2, "    - [P] root shard stage totals: primary -> auxiliary {:.1f} s; "
+               "symmetry unfold/copy {:.1f} s; k -> R GEMM {:.1f} s; "
+               "Hadamard {:.1f} s; R -> irreducible-q GEMM {:.1f} s",
+            prim_to_aux_seconds, unfold_seconds, k_to_R_seconds,
+            hadamard_seconds, R_to_q_seconds);
+    app_log(2, "    - [P] root shard compute complete; entering final synchronization");
+    app_log_flush();
     dPi_tqPQ.communicator()->barrier();
     _Timer.stop("EVALUATE_PI_R");
+    app_log(2, "    - [P] R-space polarization complete in {:.1f} s\n",
+            std::chrono::duration<double>(progress_clock::now() - progress_start).count());
+    app_log_flush();
     return dPi_tqPQ;
   }
 
@@ -319,8 +400,15 @@ namespace solvers {
     auto Pi_qtPQ = dPi_qtPQ.local();
     Pi_qtPQ() = 0.0;
 
+    using progress_clock = std::chrono::steady_clock;
+    auto progress_start = progress_clock::now();
+    const size_t total_work = size_t(nqpts) * ns * nkpts;
+    const size_t progress_stride = std::max<size_t>(1, (total_work + 9) / 10);
+    app_log(2, "  - [P] k-space convolution: {} q/spin/k work units", total_work);
+    app_log_flush();
+
     _Timer.start("PI_HADPROD_K");
-    for (size_t qsk = 0; qsk < nqpts*ns*nkpts; ++qsk) {
+    for (size_t qsk = 0; qsk < total_work; ++qsk) {
       // qskt = iq*ns*nkpts + is*nkpts + ik
       size_t iq = qsk / (ns*nkpts);
       size_t is = (qsk / nkpts) % ns;
@@ -331,8 +419,20 @@ namespace solvers {
       auto Gp_kmq = Gp_sktPQ_c(is, ikmq, nda::ellipsis{});
       auto Pi = Pi_qtPQ(iq, nda::ellipsis{});
       Pi += had_prod2(Gp_kmq, Gn_k);
+
+      const size_t done = qsk + 1;
+      if (done == 1 or done == total_work or done % progress_stride == 0) {
+        const double elapsed = std::chrono::duration<double>(progress_clock::now() - progress_start).count();
+        const double eta = (done < total_work)? elapsed * double(total_work - done) / double(done) : 0.0;
+        app_log(2, "  - [P] k-space convolution {}/{} ({:.0f}%): elapsed {:.1f} s, ETA {:.1f} s",
+                done, total_work, 100.0 * double(done) / double(total_work), elapsed, eta);
+        app_log_flush();
+      }
     }
     _Timer.stop("PI_HADPROD_K");
+    app_log(2, "  - [P] k-space convolution complete in {:.1f} s\n",
+            std::chrono::duration<double>(progress_clock::now() - progress_start).count());
+    app_log_flush();
   }
 
   auto scr_coulomb_t::eval_Pi_rpa_active(const nda::ArrayOfRank<5> auto &G_tskij, THC_ERI auto &thc,

--- a/src/methods/scr_coulomb/scr_coulomb_t.cpp
+++ b/src/methods/scr_coulomb/scr_coulomb_t.cpp
@@ -19,6 +19,7 @@
  */
 
 
+#include <chrono>
 #include <unordered_set>
 #include "methods/ERI/thc_reader_t.hpp"
 #include "methods/HF/thc_solver_comm.hpp"
@@ -61,6 +62,9 @@ namespace solvers {
   void scr_coulomb_t::update_w(MBState &mb_state, THC_ERI auto &thc, long h5_iter) {
     using math::nda::make_distributed_array;
     using math::shm::make_shared_array;
+    using progress_clock = std::chrono::steady_clock;
+
+    const auto update_start = progress_clock::now();
 
     // http://patorjk.com/software/taag/#p=display&f=Calvin%20S&t=COQUI%20screened%20coulomb
     app_log(1, "╔═╗╔═╗╔═╗ ╦ ╦╦  ┌─┐┌─┐┬─┐┌─┐┌─┐┌┐┌┌─┐┌┬┐  ┌─┐┌─┐┬ ┬┬  ┌─┐┌┬┐┌┐ \n"
@@ -92,12 +96,17 @@ namespace solvers {
         }
       }
     }
+    const auto pi_start = progress_clock::now();
     auto dPi_tqPQ = eval_Pi_qdep(mb_state, thc);
+    const double pi_seconds = std::chrono::duration<double>(progress_clock::now() - pi_start).count();
 
     // evaluate screened interaction (dW_tqPQ) and reset polarizability (dPi_tqPQ)
     // a) dPi_tqPQ is reset during dyson_W_from_Pi_tau()
     // b) pgrid and bsize of dW_tqPQ are forced to be the same as in dPi_tqPQ
+    const auto dyson_start = progress_clock::now();
     auto dW_tqPQ = dyson_W_from_Pi_tau<false>(dPi_tqPQ, thc, true);
+    const double dyson_seconds = std::chrono::duration<double>(progress_clock::now() - dyson_start).count();
+    const auto head_store_start = progress_clock::now();
     auto [eps_inv_head_q, eps_inv_head] =
         div_utils::eps_inv_head_t(dW_tqPQ, thc, *thc.MF(), _ft, _div_treatment);
     mb_state.eps_inv_head = eps_inv_head;
@@ -129,6 +138,16 @@ namespace solvers {
                         mb_state.coqui_prefix, h5_iter,
                         thc.mpi()->comm, *thc.MF());
     }
+    const double head_store_seconds =
+        std::chrono::duration<double>(progress_clock::now() - head_store_start).count();
+    const double total_seconds = std::chrono::duration<double>(progress_clock::now() - update_start).count();
+    app_log(2, "\n  Screening timing for this update");
+    app_log(2, "  --------------------------------");
+    app_log(2, "    P evaluation:                 {:.3f} sec", pi_seconds);
+    app_log(2, "    tau->omega, W Dyson, omega->tau: {:.3f} sec", dyson_seconds);
+    app_log(2, "    dielectric head and W storage:  {:.3f} sec", head_store_seconds);
+    app_log(2, "    Total update_w:                  {:.3f} sec\n", total_seconds);
+    app_log_flush();
   }
 
   template<bool w_out, nda::MemoryArrayOfRank<4> local_Array_t, typename communicator_t>
@@ -159,6 +178,8 @@ namespace solvers {
       memory::darray_t<Array_4D_t, communicator_t> &dPi_wqPQ,
       THC_ERI auto &thc) {
 
+    using progress_clock = std::chrono::steady_clock;
+    const auto progress_start = progress_clock::now();
     _Timer.start("EVALUATE_W");
     auto [nw, nqpts, NP, NQ] = dPi_wqPQ.global_shape();
     auto [nw_loc, nq_loc, NP_loc, NQ_loc] = dPi_wqPQ.local_shape();
@@ -175,6 +196,9 @@ namespace solvers {
     app_log(2, "  Evaluation of the screened interaction:");
     app_log(2, "    - processor grid for Pi/W: (w, q, P, Q) = ({}, {}, {}, {})", pgrid[0], pgrid[1], pgrid[2], pgrid[3]);
     app_log(2, "    - block size: (w, q, P, Q) = ({}, {}, {}, {})\n", block_size[0], block_size[1], block_size[2], block_size[3]);
+    app_log(2, "    - [W] root shard: q offset {}, {} local q-points x {} local frequencies",
+            q_origin, nq_loc, nw_loc);
+    app_log_flush();
 
     // Setup wq_intra_comm
     mpi3::communicator wq_intra_comm = thc.mpi()->comm.split(w_origin*nqpts + q_origin, thc.mpi()->comm.rank());
@@ -205,6 +229,8 @@ namespace solvers {
     auto Pi_PQ = dPi_PQ.local();
     auto Z_PQ = dZ_PQ.local();
     auto A_PQ = dA_PQ.local();
+    const size_t total_work = size_t(nq_loc) * size_t(nw_loc);
+    const size_t progress_stride = std::max<size_t>(1, (total_work + 9) / 10);
     for (size_t iq_loc = 0; iq_loc < nq_loc; ++iq_loc) {
       long iq = q_origin + iq_loc;
       Z_PQ = thc.Z(iq, P_rng, Q_rng, qpool_id, pgrid[1], q_intra_comm);
@@ -232,6 +258,15 @@ namespace solvers {
         // W = ([I - Z*Pi(w)]^{-1} - I) * Z
         math::nda::slate_ops::multiply(dA_PQ, dZ_PQ, dPi_PQ);
         Pi_wqPQ(n, iq_loc, nda::ellipsis{}) = Pi_PQ;
+
+        const size_t done = iq_loc * size_t(nw_loc) + n + 1;
+        if (done == 1 or done == total_work or done % progress_stride == 0) {
+          const double elapsed = std::chrono::duration<double>(progress_clock::now() - progress_start).count();
+          const double eta = (done < total_work)? elapsed * double(total_work - done) / double(done) : 0.0;
+          app_log(2, "    - [W] root (q,omega) shard {}/{} ({:.0f}%): elapsed {:.1f} s, ETA {:.1f} s",
+                  done, total_work, 100.0 * double(done) / double(total_work), elapsed, eta);
+          app_log_flush();
+        }
       }
     }
     // prevent dead block in thc.Z() in case nq_loc is not the same for all processors
@@ -239,6 +274,9 @@ namespace solvers {
       Z_PQ = thc.Z(0, P_rng, Q_rng, qpool_id, pgrid[1], q_intra_comm);
 
     _Timer.stop("EVALUATE_W");
+    app_log(2, "    - [W] root Dyson shard completed in {:.1f} s\n",
+            std::chrono::duration<double>(progress_clock::now() - progress_start).count());
+    app_log_flush();
 
   }
 
@@ -386,7 +424,9 @@ namespace solvers {
   -> memory::darray_t<local_Array_t, mpi3::communicator>
   {
     using math::nda::make_distributed_array;
+    using progress_clock = std::chrono::steady_clock;
 
+    const auto transform_start = progress_clock::now();
     _Timer.start("IMAG_FT_TtoW");
     auto comm = dPi_tqPQ_pos.communicator();
     long npts = dPi_tqPQ_pos.global_shape()[1];
@@ -394,6 +434,8 @@ namespace solvers {
     long nw_half = (_ft->nw_b()%2==0)? _ft->nw_b()/2 : _ft->nw_b()/2 + 1;
     std::array<long, 4> w_gshape = {nw_half, npts, Np, Np};
     std::array<long, 4> t_gshape = dPi_tqPQ_pos.global_shape();
+    app_log(2, "  [W] tau -> omega transform begin: {} tau points -> {} frequencies", t_gshape[0], w_gshape[0]);
+    app_log_flush();
 
     if (dPi_tqPQ_pos.communicator()->size() == 1) {
       _ft->check_leakage(dPi_tqPQ_pos, imag_axes_ft::boson, "polarizability", true);
@@ -405,6 +447,9 @@ namespace solvers {
       _ft->tau_to_w_PHsym(Pi_ti_loc, Pi_wi_loc);
       if (reset_input) dPi_tqPQ_pos.reset();
       _Timer.stop("IMAG_FT_TtoW");
+      app_log(2, "  [W] tau -> omega transform complete in {:.1f} s\n",
+              std::chrono::duration<double>(progress_clock::now() - transform_start).count());
+      app_log_flush();
       return dPi_wqPQ;
     }
     // redistribute to cover (tau, w)-axes locally -> FT locally -> redistribute back
@@ -420,33 +465,54 @@ namespace solvers {
     }
     auto buffer_ti  = make_distributed_array<local_Array_t>(
         *comm, b_pgrid, t_gshape, dPi_tqPQ_pos.block_size());
+    app_log(2, "    - [W] tau -> omega: redistribute tau data to transform layout");
+    app_log_flush();
+    const auto input_redistribute_start = progress_clock::now();
     _Timer.start("FT_REDISTRIBUTE");
     math::nda::redistribute(dPi_tqPQ_pos, buffer_ti);
     _Timer.stop("FT_REDISTRIBUTE");
+    app_log(2, "    - [W] tau -> omega: input redistribution complete in {:.1f} s",
+            std::chrono::duration<double>(progress_clock::now() - input_redistribute_start).count());
+    app_log_flush();
     if (reset_input) dPi_tqPQ_pos.reset();
     _ft->check_leakage(buffer_ti, imag_axes_ft::boson, "polarizability", true);
     buffer_ti.communicator()->barrier();
 
     auto buffer_wi  = make_distributed_array<local_Array_t>(
         *comm, b_pgrid, w_gshape, buffer_ti.block_size());
+    app_log(2, "    - [W] tau -> omega: local particle-hole-symmetric transform");
+    app_log_flush();
+    const auto local_transform_start = progress_clock::now();
     {
       auto buf_ti_loc = buffer_ti.local();
       auto buf_wi_loc = buffer_wi.local();
       _ft->tau_to_w_PHsym(buf_ti_loc, buf_wi_loc);
     }
+    app_log(2, "    - [W] tau -> omega: local transform complete in {:.1f} s",
+            std::chrono::duration<double>(progress_clock::now() - local_transform_start).count());
+    app_log_flush();
     buffer_ti.reset();
     buffer_wi.communicator()->barrier();
 
     auto dPi_wqPQ = make_distributed_array<local_Array_t>(
         *comm, w_pgrid_out, w_gshape, w_bsize_out);
 
+    app_log(2, "    - [W] tau -> omega: redistribute frequency data to Dyson layout");
+    app_log_flush();
+    const auto output_redistribute_start = progress_clock::now();
     _Timer.start("FT_REDISTRIBUTE");
     math::nda::redistribute(buffer_wi, dPi_wqPQ);
     _Timer.stop("FT_REDISTRIBUTE");
+    app_log(2, "    - [W] tau -> omega: output redistribution complete in {:.1f} s",
+            std::chrono::duration<double>(progress_clock::now() - output_redistribute_start).count());
+    app_log_flush();
     buffer_wi.reset();
     dPi_wqPQ.communicator()->barrier();
 
     _Timer.stop("IMAG_FT_TtoW");
+    app_log(2, "  [W] tau -> omega transform complete in {:.1f} s\n",
+            std::chrono::duration<double>(progress_clock::now() - transform_start).count());
+    app_log_flush();
     return dPi_wqPQ;
   }
 
@@ -458,7 +524,9 @@ namespace solvers {
   -> memory::darray_t<local_Array_t, mpi3::communicator>
   {
     using math::nda::make_distributed_array;
+    using progress_clock = std::chrono::steady_clock;
 
+    const auto transform_start = progress_clock::now();
     _Timer.start("IMAG_FT_WtoT");
     auto comm = dW_wqPQ_pos.communicator();
     long npts = dW_wqPQ_pos.global_shape()[1];
@@ -466,6 +534,8 @@ namespace solvers {
     auto w_gshape = dW_wqPQ_pos.global_shape();
     size_t nt_half = (_ft->nt_b()%2==0)? _ft->nt_b() / 2 : _ft->nt_b() / 2 + 1;
     std::array<long, 4> t_gshape = {nt_half, npts, Np, Np};
+    app_log(2, "  [W] omega -> tau transform begin: {} frequencies -> {} tau points", w_gshape[0], t_gshape[0]);
+    app_log_flush();
 
     if (dW_wqPQ_pos.communicator()->size() == 1) {
       auto dW_tqPQ = make_distributed_array<local_Array_t>(
@@ -477,6 +547,9 @@ namespace solvers {
       if (reset_input) dW_wqPQ_pos.reset();
       _ft->check_leakage(dW_tqPQ, imag_axes_ft::boson, "screened interation", true);
       _Timer.stop("IMAG_FT_WtoT");
+      app_log(2, "  [W] omega -> tau transform complete in {:.1f} s\n",
+              std::chrono::duration<double>(progress_clock::now() - transform_start).count());
+      app_log_flush();
       return dW_tqPQ;
     }
 
@@ -493,30 +566,51 @@ namespace solvers {
     }
     auto buffer_wi  = make_distributed_array<local_Array_t>(
         *comm, b_pgrid, w_gshape, dW_wqPQ_pos.block_size());
+    app_log(2, "    - [W] omega -> tau: redistribute frequency data to transform layout");
+    app_log_flush();
+    const auto input_redistribute_start = progress_clock::now();
     _Timer.start("FT_REDISTRIBUTE");
     math::nda::redistribute(dW_wqPQ_pos, buffer_wi);
     _Timer.stop("FT_REDISTRIBUTE");
+    app_log(2, "    - [W] omega -> tau: input redistribution complete in {:.1f} s",
+            std::chrono::duration<double>(progress_clock::now() - input_redistribute_start).count());
+    app_log_flush();
     if (reset_input) dW_wqPQ_pos.reset();
 
     auto buffer_ti  = make_distributed_array<local_Array_t>(
         *comm, b_pgrid, t_gshape, buffer_wi.block_size());
+    app_log(2, "    - [W] omega -> tau: local particle-hole-symmetric transform");
+    app_log_flush();
+    const auto local_transform_start = progress_clock::now();
     {
       auto buf_ti_loc = buffer_ti.local();
       auto buf_wi_loc = buffer_wi.local();
       _ft->w_to_tau_PHsym(buf_wi_loc, buf_ti_loc);
     }
+    app_log(2, "    - [W] omega -> tau: local transform complete in {:.1f} s",
+            std::chrono::duration<double>(progress_clock::now() - local_transform_start).count());
+    app_log_flush();
     buffer_wi.reset();
     _ft->check_leakage(buffer_ti, imag_axes_ft::boson, "screened interaction", true);
 
     auto dW_tqPQ = make_distributed_array<local_Array_t>(
         *comm, t_pgrid_out, t_gshape, t_bsize_out);
 
+    app_log(2, "    - [W] omega -> tau: redistribute tau data to output layout");
+    app_log_flush();
+    const auto output_redistribute_start = progress_clock::now();
     _Timer.start("FT_REDISTRIBUTE");
     math::nda::redistribute(buffer_ti, dW_tqPQ);
     _Timer.stop("FT_REDISTRIBUTE");
+    app_log(2, "    - [W] omega -> tau: output redistribution complete in {:.1f} s",
+            std::chrono::duration<double>(progress_clock::now() - output_redistribute_start).count());
+    app_log_flush();
     buffer_ti.reset();
 
     _Timer.stop("IMAG_FT_WtoT");
+    app_log(2, "  [W] omega -> tau transform complete in {:.1f} s\n",
+            std::chrono::duration<double>(progress_clock::now() - transform_start).count());
+    app_log_flush();
     return dW_tqPQ;
   }
 


### PR DESCRIPTION
## Motivation

Some GW Sigma and polarization (P) calculations can spend a long time in individual stages without producing output. This makes it difficult to tell whether the calculation is still making progress or has actually stalled.

## Changes

- add explicit start and completion messages for long-running Sigma and P stages
- flush progress messages immediately so they remain visible while a calculation is running
- report completed work, elapsed time, and estimated remaining time for local tau slices and polarization work units
- add stage-level timings around Sigma transformations, divergence correction, polarization contractions, Fourier transforms, and data redistribution
- reset per-update timers so the reported diagnostics describe the current calculation stage

These diagnostics are intended to make long GW runs easier to monitor and to distinguish slow but healthy progress from a genuine hang.