### PR TITLE
fix: update cppdlr symmetric grid dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -497,7 +497,11 @@ if(COQUI_PYTHON_SUPPORT)
     GIT_TAG        unstable
     EXCLUDE_FROM_ALL
   )
-  FetchContent_MakeAvailable(c2py)
+  # NDA's h5 dependency may already provide c2py when Python support is enabled.
+  # Reuse that target instead of adding the same FetchContent project twice.
+  if(NOT TARGET c2py::c2py)
+    FetchContent_MakeAvailable(c2py)
+  endif()
 
   if (COQUI_UPDATE_PYTHON_BINDINGS)
     find_program(clair-c2py clair-c2py REQUIRED)
@@ -561,7 +565,8 @@ if(ENABLE_DLR)
   FetchContent_Declare(
       cppdlr
       GIT_REPOSITORY https://github.com/flatironinstitute/cppdlr.git
-      GIT_TAG        f6bd6ab1823403015486c2c6b3399fd4db4468c1 #main
+      # cppdlr PR #20: include self-symmetric fixed points in SYM grids.
+      GIT_TAG        6f3f2d836d43da7a01b4e53292ad49f896a19667
   )
   FetchContent_MakeAvailable(cppdlr)
   # temporary workaround before cppdlr's nda dependency is updated. 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -571,7 +571,8 @@ if(ENABLE_DLR)
   FetchContent_Declare(
       cppdlr
       GIT_REPOSITORY https://github.com/flatironinstitute/cppdlr.git
-      GIT_TAG        f6bd6ab1823403015486c2c6b3399fd4db4468c1 #main
+      # Pin cppdlr main as of 2026-09-09.
+      GIT_TAG        7a0f60cba2da69d64361971613b6859bb8c078ce
   )
   FetchContent_MakeAvailable(cppdlr)
   # temporary workaround before cppdlr's nda dependency is updated. 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -568,6 +568,10 @@ if(ENABLE_DLR)
     set(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT FALSE)
   endif()
 
+  # Allow a user-provided cppdlr source tree
+  if(DEFINED CPPDLR)
+    set(FETCHCONTENT_SOURCE_DIR_CPPDLR ${CPPDLR})
+  endif()
   FetchContent_Declare(
       cppdlr
       GIT_REPOSITORY https://github.com/flatironinstitute/cppdlr.git

--- a/src/methods/SCF/tests/test_scf_common.cpp
+++ b/src/methods/SCF/tests/test_scf_common.cpp
@@ -190,10 +190,10 @@ namespace bdft_tests {
     auto& mpi_context = utils::make_unit_test_mpi_context();
 
     // Cheap setup for regression: short beta and compact THC factors. wmax must
-    // cover the spectrum of H0+F relative to mu (max|eps-mu| = 2.11 a.u. here);
+    // cover the spectrum of H0+F relative to mu (max|eps_max-eps_min| ~ 5 a.u. here);
     // a narrower window leaves G outside the DLR's representable range, and the
     // converged energies then vary by ~1e-6 between BLAS/LAPACK implementations.
-    imag_axes_ft::IAFT ft(100.0, 2.4, imag_axes_ft::dlr_basis);
+    imag_axes_ft::IAFT ft(100.0, 7.0, imag_axes_ft::dlr_basis);
     auto mf = std::make_shared<mf::MF>(mf::default_MF(mpi_context, "qe_lih222"));
 
     auto run_dyson_gw = [&](iter_scf::iter_scf_t &iter_sol, const std::string &output)
@@ -221,14 +221,14 @@ namespace bdft_tests {
     auto [e_hf_damp, e_corr_damp] = run_dyson_gw(damp_sol, "dyson_gw_damping_test");
     auto [e_hf_diis, e_corr_diis] = run_dyson_gw(diis_sol, "dyson_gw_diis_test");
 
-    // Damping reference for this cheap setup; DIIS should converge to the same state.
-    constexpr double e_hf_ref = -0.4146530183717176 + -3.8314258924454028;
-    constexpr double e_corr_ref = -0.0887842498009347;
-    constexpr double tol = 1e-6;
-    VALUE_EQUAL(e_hf_damp, e_hf_ref, tol, tol);
-    VALUE_EQUAL(e_corr_damp, e_corr_ref, tol, tol);
-    VALUE_EQUAL(e_hf_diis, e_hf_ref, tol, tol);
-    VALUE_EQUAL(e_corr_diis, e_corr_ref, tol, tol);
+    // Reference from a converged wmax = 10.0 run with accuracy ~ 1e-7.
+    constexpr double e_hf_ref = -0.41469260619183446 + -3.8312790207998515;
+    constexpr double e_corr_ref = -0.0890230059782452;
+    constexpr double abs_tol = 1e-6;
+    VALUE_EQUAL(e_hf_damp, e_hf_ref, abs_tol, abs_tol);
+    VALUE_EQUAL(e_corr_damp, e_corr_ref, abs_tol, abs_tol);
+    VALUE_EQUAL(e_hf_diis, e_hf_ref, abs_tol, abs_tol);
+    VALUE_EQUAL(e_corr_diis, e_corr_ref, abs_tol, abs_tol);
   }
 
 

--- a/src/numerics/imag_axes_ft/iaft_utils.cpp
+++ b/src/numerics/imag_axes_ft/iaft_utils.cpp
@@ -21,12 +21,165 @@
 #include "numerics/imag_axes_ft/iaft_utils.hpp"
 
 #include <cmath>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <type_traits>
 
 #include "h5/h5.hpp"
 
+#include "IO/app_loggers.h"
+#include "utilities/check.hpp"
 #include "numerics/imag_axes_ft/IAFT.hpp"
 
 namespace imag_axes_ft {
+
+  namespace {
+
+    constexpr std::string_view grid_mismatch_explanation =
+      "The imaginary-axis grid is rebuilt from the checkpoint's metadata (beta, wmax,\n"
+      "prec/eps), so it reproduces the original only when the DLR/IR backend builds the same\n"
+      "grid between the code that wrote the checkpoint and the code reading it now. A\n"
+      "difference means the two disagree, typically because the basis library was updated in\n"
+      "between. Rebuild CoQui using the consistent DLR/IR backend or regenerate the checkpoint\n"
+      "with the current build.";
+
+    /**
+     * Implementation of the two compare_mesh overloads.
+     *
+     * @param label    - mesh name to use in the report
+     * @param scf_file - checkpoint path, for the report
+     * @param stored   - mesh read back from the checkpoint
+     * @param rebuilt  - mesh of the reconstructed IAFT
+     * @param tol      - absolute tolerance on node values; unused for integral value_t
+     * @return true when the meshes agree
+     */
+    template<typename value_t>
+    bool compare_mesh_impl(std::string_view label, std::string const& scf_file,
+                           nda::array<value_t, 1> const& stored,
+                           nda::array<value_t, 1> const& rebuilt,
+                           [[maybe_unused]] double tol) {
+      if (stored.size() != rebuilt.size()) {
+        app_log(1, " {} has {} nodes in '{}',\n"
+                   "but rebuilding the grid from the stored metadata gives {} nodes.\n"
+                   "{}",
+                label, stored.size(), scf_file, rebuilt.size(), grid_mismatch_explanation);
+        return false;
+      }
+
+      for (long i = 0; i < stored.size(); ++i) {
+        bool differs;
+        if constexpr (std::is_integral_v<value_t>)
+          differs = (stored(i) != rebuilt(i));
+        else
+          differs = (std::abs(stored(i) - rebuilt(i)) > tol);
+
+        if (differs) {
+          app_log(1, " {} in '{}' differs at index {}:\n"
+                     "the checkpoint has {}, the rebuilt grid has {}.\n"
+                     "{}",
+                  label, scf_file, i, stored(i), rebuilt(i), grid_mismatch_explanation);
+          return false;
+        }
+      }
+      return true;
+    }
+
+    /**
+     * Read one mesh from the checkpoint and compare it against the rebuilt one,
+     * aborting on disagreement. A mesh that is not present is reported and skipped:
+     * absence is never an error.
+     *
+     * @param parent      - group holding the mesh datasets (tau_mesh or iwn_mesh)
+     * @param dataset     - "fermion" or "boson"
+     * @param label       - mesh name to use in log and error messages
+     * @param rebuilt     - mesh of the reconstructed IAFT
+     * @param scf_file    - checkpoint path, for the messages
+     * @param tol         - absolute tolerance; only meaningful for floating-point meshes
+     */
+    template<typename value_t>
+    void check_one_mesh(h5::group const& parent, std::string const& dataset,
+                        std::string_view label, nda::array<value_t, 1> const& rebuilt,
+                        std::string const& scf_file, double tol = 0.0) {
+      app_log(4, "  Checking for {} in '{}'.", label, scf_file);
+      if (not parent.has_dataset(dataset)) {
+        app_log(1, " [WARNING] {} is absent from '{}';\n"
+                   "this part of the grid could not be verified.", label, scf_file);
+        return;
+      }
+
+      nda::array<value_t, 1> stored;
+      nda::h5_read(parent, dataset, stored);
+
+      bool agrees;
+      if constexpr (std::is_integral_v<value_t>)
+        agrees = compare_mesh(label, scf_file, stored, rebuilt);
+      else
+        agrees = compare_mesh(label, scf_file, stored, rebuilt, tol);
+
+      utils::check(agrees,
+        "iaft_utils.cpp::validate_grid_against_checkpoint: \n"
+        "{} in '{}' does not match the grid rebuilt from the checkpoint's own \n"
+        "metadata; see the report above.",
+        label, scf_file);
+
+      app_log(4, "  {} matches.", label);
+    }
+
+  } // anonymous namespace
+
+  bool compare_mesh(std::string_view label, std::string const& scf_file,
+                    nda::array<double, 1> const& stored,
+                    nda::array<double, 1> const& rebuilt,
+                    double tol) {
+    return compare_mesh_impl(label, scf_file, stored, rebuilt, tol);
+  }
+
+  bool compare_mesh(std::string_view label, std::string const& scf_file,
+                    nda::array<long, 1> const& stored,
+                    nda::array<long, 1> const& rebuilt) {
+    return compare_mesh_impl<long>(label, scf_file, stored, rebuilt, 0.0);
+  }
+
+  void validate_grid_against_checkpoint(h5::group const& iaft_grp, IAFT const& ft,
+                                        std::string const& scf_file) {
+    constexpr double tau_tol = 1e-10;
+
+    bool const has_tau = iaft_grp.has_subgroup("tau_mesh");
+    bool const has_iwn = iaft_grp.has_subgroup("iwn_mesh");
+
+    if (not has_tau and not has_iwn) {
+      app_log(1, " [WARNING] '{}' stores no tau_mesh or iwn_mesh since it was written \n"
+                 "by an older version of CoQui, so its imaginary-axis grid could not be \n"
+                 "verified against the one rebuilt from its metadata.", scf_file);
+      return;
+    }
+
+    app_log(2, "Verifying the imaginary-axis grid of '{}' against the rebuilt IAFT.", scf_file);
+
+    if (has_tau) {
+      auto tau_grp = iaft_grp.open_group("tau_mesh");
+      check_one_mesh<double>(tau_grp, "fermion", "tau_mesh (fermion)",
+                             ft.tau_mesh_f(), scf_file, tau_tol);
+      check_one_mesh<double>(tau_grp, "boson", "tau_mesh (boson)",
+                             ft.tau_mesh_b(), scf_file, tau_tol);
+    } else {
+      app_log(1, " [WARNING] '{}' stores no tau_mesh;\n"
+                 "the imaginary-time grid could not be verified.", scf_file);
+    }
+
+    if (has_iwn) {
+      auto iwn_grp = iaft_grp.open_group("iwn_mesh");
+      check_one_mesh<long>(iwn_grp, "fermion", "iwn_mesh (fermion)",
+                           ft.wn_mesh_f(), scf_file);
+      check_one_mesh<long>(iwn_grp, "boson", "iwn_mesh (boson)",
+                           ft.wn_mesh_b(), scf_file);
+    } else {
+      app_log(1, " [WARNING] '{}' stores no iwn_mesh; the Matsubara grid could not be verified.", scf_file);
+    }
+
+    app_log(2, " Imaginary-axis grid of '{}' verified.", scf_file);
+  }
 
   IAFT read_iaft(std::string scf_file, bool print_meta_log) {
     double beta;
@@ -68,23 +221,31 @@ namespace imag_axes_ft {
     }
 
     auto const basis_enum = string_to_basis_enum(basis);
-    if (basis_enum == dlr_basis) {
-      utils::check(prec.has_value() || eps.has_value(),
-        "iaft_utils.cpp::read_iaft: DLR checkpoint must provide at least one of prec or eps.");
+    auto build_iaft = [&]() -> IAFT {
+      if (basis_enum == dlr_basis) {
+        utils::check(prec.has_value() || eps.has_value(),
+          "iaft_utils.cpp::read_iaft: DLR checkpoint must provide at least one of prec or eps.");
 
-      bool const build_with_eps = eps.has_value() && (!prec.has_value() || *prec == "custom");
-      if (build_with_eps) {
-        return IAFT(beta, wmax, basis_enum, *eps, print_meta_log);
+        bool const build_with_eps = eps.has_value() && (!prec.has_value() || *prec == "custom");
+        if (build_with_eps) {
+          return IAFT(beta, wmax, basis_enum, *eps, print_meta_log);
+        }
+
+        utils::check(prec.has_value(),
+          "iaft_utils.cpp::read_iaft: DLR checkpoint is missing required IAFT prec metadata.");
+        return IAFT(beta, wmax, basis_enum, *prec, print_meta_log);
       }
 
       utils::check(prec.has_value(),
-        "iaft_utils.cpp::read_iaft: DLR checkpoint is missing required IAFT prec metadata.");
+        "iaft_utils.cpp::read_iaft: checkpoint is missing required IAFT prec metadata.");
       return IAFT(beta, wmax, basis_enum, *prec, print_meta_log);
-    }
+    };
 
-    utils::check(prec.has_value(),
-      "iaft_utils.cpp::read_iaft: checkpoint is missing required IAFT prec metadata.");
-    return IAFT(beta, wmax, basis_enum, *prec, print_meta_log);
+    // Rebuild the grid from the checkpoint's metadata.
+    auto ft = build_iaft();
+    // Validate that the rebuilt grid matches the one that the simulated data lives on. 
+    validate_grid_against_checkpoint(iaft_grp, ft, scf_file);
+    return ft;
   }
 
   namespace test_utils {

--- a/src/numerics/imag_axes_ft/iaft_utils.hpp
+++ b/src/numerics/imag_axes_ft/iaft_utils.hpp
@@ -23,8 +23,10 @@
 #define COQUI_IAFT_UTILS_HPP
 
 #include <string>
+#include <string_view>
 
 #include "configuration.hpp"
+#include "h5/h5.hpp"
 #include "nda/nda.hpp"
 #include "IAFT.hpp"
 
@@ -86,10 +88,55 @@ namespace imag_axes_ft {
   } // namespace test_utils
 
   /**
-   * Reconstruct IAFT object from the metadata in bdft scf output
+   * Reconstruct IAFT object from the metadata in CoQui checkpoint file. 
    * @return IAFT
    */
   IAFT read_iaft(std::string scf_file, bool print_meta_log = true);
+
+  /**
+   * Compare a mesh stored in a checkpoint against the same mesh of a grid rebuilt from
+   * that checkpoint's scalar metadata. 
+   *
+   * @param label    - mesh name to use in the report
+   * @param scf_file - checkpoint path, for the report
+   * @param stored   - mesh read back from the checkpoint
+   * @param rebuilt  - mesh of the freshly constructed IAFT
+   * @param tol      - absolute tolerance on node values
+   * @return true when the meshes agree
+   */
+  bool compare_mesh(std::string_view label, std::string const& scf_file,
+                    nda::array<double, 1> const& stored,
+                    nda::array<double, 1> const& rebuilt,
+                    double tol);
+
+  /**
+   * Overload for the integer Matsubara index meshes
+   *
+   * @param label    - mesh name to use in the report
+   * @param scf_file - checkpoint path, for the report
+   * @param stored   - mesh read back from the checkpoint
+   * @param rebuilt  - mesh of the freshly constructed IAFT
+   * @return true when the meshes agree
+   */
+  bool compare_mesh(std::string_view label, std::string const& scf_file,
+                    nda::array<long, 1> const& stored,
+                    nda::array<long, 1> const& rebuilt);
+
+  /**
+   * Verify that the tau/iwn meshes stored in a checkpoint match those of the IAFT
+   * rebuilt from the same checkpoint's metadata, and abort if they do not.
+   *
+   * A rebuild from (beta, wmax, prec|eps) reproduces the original grid only if the
+   * DLR/IR backend builds it the same way in the writing and reading builds, so this
+   * catches any basis-library change that alters the grid. 
+   *
+   * @param iaft_grp - the checkpoint's "imaginary_fourier_transform" group
+   * @param ft       - IAFT rebuilt from that group's scalar metadata
+   * @param scf_file - checkpoint path, used in the messages
+   */
+  void validate_grid_against_checkpoint(h5::group const& iaft_grp, IAFT const& ft,
+                                        std::string const& scf_file);
+
 
 } // imag_axes_ft
 

--- a/src/numerics/imag_axes_ft/tests/test_iaft.cpp
+++ b/src/numerics/imag_axes_ft/tests/test_iaft.cpp
@@ -285,4 +285,53 @@ namespace bdft_tests {
 
   }
 
+  TEST_CASE("iaft_compare_mesh", "[iaft]") {
+    using imag_axes_ft::compare_mesh;
+    std::string const chkpt = "unit_test.mbpt.h5";
+
+    SECTION("identical_tau_meshes_agree") {
+      nda::array<double, 1> a = {-1.0, -0.5, 0.0, 0.5, 1.0};
+      nda::array<double, 1> b = {-1.0, -0.5, 0.0, 0.5, 1.0};
+      REQUIRE(compare_mesh("tau_mesh (fermion)", chkpt, a, b, 1e-10));
+    }
+
+    SECTION("tau_mesh_size_mismatch_disagrees") {
+      nda::array<double, 1> stored  = {-1.0, 0.0, 1.0};
+      nda::array<double, 1> rebuilt = {-1.0, -0.5, 0.0, 0.5, 1.0};
+      REQUIRE_FALSE(compare_mesh("tau_mesh (fermion)", chkpt, stored, rebuilt, 1e-10));
+    }
+
+    SECTION("tau_mesh_value_mismatch_disagrees") {
+      nda::array<double, 1> stored  = {-1.0, -0.5, 0.0, 0.5, 1.0};
+      nda::array<double, 1> rebuilt = {-1.0, -0.5, 0.0, 0.25, 1.0};
+      REQUIRE_FALSE(compare_mesh("tau_mesh (fermion)", chkpt, stored, rebuilt, 1e-10));
+    }
+
+    SECTION("tau_mesh_difference_within_tolerance_agrees") {
+      nda::array<double, 1> stored  = {-1.0, -0.5, 0.0, 0.5, 1.0};
+      nda::array<double, 1> rebuilt = {-1.0, -0.5, 0.0, 0.5 + 1e-13, 1.0};
+      REQUIRE(compare_mesh("tau_mesh (fermion)", chkpt, stored, rebuilt, 1e-10));
+    }
+
+    SECTION("identical_iwn_meshes_agree") {
+      nda::array<long, 1> a = {-3, -1, 1, 3};
+      nda::array<long, 1> b = {-3, -1, 1, 3};
+      REQUIRE(compare_mesh("iwn_mesh (fermion)", chkpt, a, b));
+    }
+
+    SECTION("iwn_mesh_off_by_one_disagrees") {
+      // integers carry no tolerance: the orientation flip shows up exactly like this
+      nda::array<long, 1> stored  = {-3, -1, 1, 3};
+      nda::array<long, 1> rebuilt = {-3, -1, 1, 5};
+      REQUIRE_FALSE(compare_mesh("iwn_mesh (fermion)", chkpt, stored, rebuilt));
+    }
+
+    SECTION("iwn_mesh_size_mismatch_disagrees") {
+      // the cppdlr symmetrized-rank change surfaces here first
+      nda::array<long, 1> stored  = {-3, -1, 1, 3};
+      nda::array<long, 1> rebuilt = {-5, -3, -1, 1, 3, 5};
+      REQUIRE_FALSE(compare_mesh("iwn_mesh (fermion)", chkpt, stored, rebuilt));
+    }
+  }
+
 } // bdft_tests

--- a/src/python/utils/imag_axes_ft/iaft.py
+++ b/src/python/utils/imag_axes_ft/iaft.py
@@ -20,6 +20,7 @@ limitations under the License.
 import os
 import numpy as np
 
+from coqui._lib.utils_module import app_log
 from .iaft_sparse_ir import _IAFTIRAdapter
 
 try:
@@ -236,6 +237,14 @@ class _IAFTCppAdapter(object):
         h5_grp['imaginary_fourier_transform']['prec'] = self.prec
         h5_grp['imaginary_fourier_transform']['eps'] = self.eps
         h5_grp['imaginary_fourier_transform']['basis'] = self.basis
+
+        iaft_grp = h5_grp['imaginary_fourier_transform']
+        iaft_grp.create_group('tau_mesh')
+        iaft_grp['tau_mesh']['fermion'] = self.tau_mesh('f', rel_notation=True)
+        iaft_grp['tau_mesh']['boson'] = self.tau_mesh('b', rel_notation=True)
+        iaft_grp.create_group('iwn_mesh')
+        iaft_grp['iwn_mesh']['fermion'] = self.wn_mesh('f')
+        iaft_grp['iwn_mesh']['boson'] = self.wn_mesh('b')
 
     def __str__(self):
         self._iaft_cpp.metadata_log()
@@ -516,6 +525,75 @@ class _IAFTCppAdapter(object):
         return None
 
 
+def _read_chkpt_meshes(iaft_grp):
+    """
+    Read the tau/iwn meshes recorded by :meth:`IAFT.save`, if the checkpoint has them.
+
+    :param iaft_grp: HDFArchive group
+        The ``'imaginary_fourier_transform'`` group.
+    :return: dict for the IAFT meshes read. Empty when the checkpoint records no meshes 
+        at all for backward compatibility. 
+    """
+    meshes = {}
+    for grp_name in ('tau_mesh', 'iwn_mesh'):
+        if grp_name not in iaft_grp:
+            continue
+        sub_grp = iaft_grp[grp_name]
+        for stats in ('fermion', 'boson'):
+            if stats in sub_grp:
+                meshes[f"{grp_name} ({stats})"] = np.array(sub_grp[stats])
+    return meshes
+
+
+def _validate_grid_against_checkpoint(iaft, stored_meshes, chkpt_h5):
+    """
+    Check that an IAFT rebuilt from a checkpoint's metadata lands on the same
+    imaginary-axis grid the stored data actually lives on.
+
+    A grid rebuilt from (beta, wmax, prec|eps) only reproduces the original if the
+    DLR/IR backend builds it the same way in the writing and reading builds, so this
+    catches any basis-library change that alters the grid. 
+
+    :raise ValueError: if any stored mesh disagrees with the rebuilt one.
+    """
+    if not stored_meshes:
+        app_log(1, f" [WARNING] '{chkpt_h5}' stores no tau_mesh or iwn_mesh since it was \n"
+                   "created using an older version of CoQui, so its imaginary-axis grid \n"
+                   "could not be verified against the one rebuilt from its metadata.")
+        return
+
+    rebuilt = {
+        'tau_mesh (fermion)': np.asarray(iaft.tau_mesh('f', rel_notation=True)),
+        'tau_mesh (boson)':   np.asarray(iaft.tau_mesh('b', rel_notation=True)),
+        'iwn_mesh (fermion)': np.asarray(iaft.wn_mesh('f')),
+        'iwn_mesh (boson)':   np.asarray(iaft.wn_mesh('b')),
+    }
+
+    explanation = (
+        f"The imaginary-axis grid is rebuilt from the checkpoint's metadata (beta, wmax, prec/eps),\n"
+        "so it reproduces the original only when the DLR/IR backend builds the same grid between \n"
+        "the code that wrote the checkpoint and the code reading it now. A difference means the two"
+        "disagree, typically because the basis library was updated in between. \n"
+        "Rebuild CoQui using the consistent DLR/IR backend or regenerate the checkpoint with the \n"
+        "current build.")
+
+    for label, stored in stored_meshes.items():
+        new = rebuilt[label]
+        # size first
+        if stored.shape != new.shape:
+            raise ValueError(
+                f"{label} has {stored.shape[0]} nodes in the checkpoint, but rebuilding "
+                f"the grid gives {new.shape[0]} nodes. {explanation}")
+        # 1e-10 for tau mesh, 0 for iwn mesh (i.e. integers)
+        tol = 0.0 if label.startswith('iwn_mesh') else 1e-10
+        diff = np.abs(stored.astype(float) - new.astype(float))
+        if np.any(diff > tol):
+            idx = int(np.argmax(diff))
+            raise ValueError(
+                f"{label} differs at index {idx}: the checkpoint has {stored[idx]}, the "
+                f"rebuilt grid has {new[idx]}. {explanation}")
+
+
 class IAFT(object):
     """
     Imaginary-axis Fourier transform (IAFT) for dynamical correlation functions.
@@ -773,8 +851,13 @@ class IAFT(object):
                 wmax = ir_lambda / beta
             # Prefer basis metadata; fall back to source for backward compatibility.
             basis = iaft_grp['basis'] if 'basis' in iaft_grp else (iaft_grp['source'] if 'source' in iaft_grp else "ir")
+            stored_meshes = _read_chkpt_meshes(iaft_grp)
 
-        return cls(beta, wmax, prec=prec, eps=eps, verbose=verbose, basis=basis)
+        iaft = cls(beta, wmax, prec=prec, eps=eps, verbose=verbose, basis=basis)
+        # The grid above was rebuilt from the scalars only; confirm it is the grid the
+        # stored data actually lives on before handing it back.
+        _validate_grid_against_checkpoint(iaft, stored_meshes, chkpt_h5)
+        return iaft
 
     def save(self, h5_grp):
         """

--- a/src/python/utils/imag_axes_ft/iaft_sparse_ir.py
+++ b/src/python/utils/imag_axes_ft/iaft_sparse_ir.py
@@ -216,6 +216,14 @@ class _IAFTIRAdapter(object):
         h5_grp['imaginary_fourier_transform']['eps'] = self.eps
         h5_grp['imaginary_fourier_transform']['basis'] = "ir"
 
+        iaft_grp = h5_grp['imaginary_fourier_transform']
+        iaft_grp.create_group('tau_mesh')
+        iaft_grp['tau_mesh']['fermion'] = self.tau_mesh('f', rel_notation=True)
+        iaft_grp['tau_mesh']['boson'] = self.tau_mesh('b', rel_notation=True)
+        iaft_grp.create_group('iwn_mesh')
+        iaft_grp['iwn_mesh']['fermion'] = self.wn_mesh('f')
+        iaft_grp['iwn_mesh']['boson'] = self.wn_mesh('b')
+
     def __str__(self):
         return ("Mesh details on the imaginary axis\n"
                 "----------------------------------\n"

--- a/src/python/utils/imag_axes_ft/tests/test_iaft.py
+++ b/src/python/utils/imag_axes_ft/tests/test_iaft.py
@@ -265,3 +265,68 @@ def test_tau_notation(basis):
     assert np.allclose(Dm_abs, Dm_rel, atol=1e-12)
 
 
+@pytest.mark.parametrize("basis", [
+    ("dlr"),
+    ("ir"),
+])
+def test_iaft_mesh_roundtrip_through_checkpoint(basis):
+    """save() must record the meshes in exactly the layout and conventions
+    chkpt_utils.cpp uses - tau on the rescaled [-1, 1] axis, wn as the CoQui odd/even
+    integer index - so that both the C++ read_iaft and from_coqui_chkpt can validate a
+    rebuilt grid against them. A checkpoint we just wrote must then load back cleanly."""
+    iaft = IAFT(beta=5.0, wmax=10.0, prec="high", basis=basis, verbose=False)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        chkpt = os.path.join(tmpdir, "iaft_mesh.h5")
+        with HDFArchive(chkpt, 'w') as ar:
+            iaft.save(ar)
+
+        with HDFArchive(chkpt, 'r') as ar:
+            grp = ar['imaginary_fourier_transform']
+            np.testing.assert_allclose(grp['tau_mesh']['fermion'],
+                                       iaft.tau_mesh('f', rel_notation=True))
+            np.testing.assert_allclose(grp['tau_mesh']['boson'],
+                                       iaft.tau_mesh('b', rel_notation=True))
+            np.testing.assert_array_equal(grp['iwn_mesh']['fermion'], iaft.wn_mesh('f'))
+            np.testing.assert_array_equal(grp['iwn_mesh']['boson'], iaft.wn_mesh('b'))
+
+        # the grid validation in from_coqui_chkpt must accept what save() just wrote
+        restored = IAFT.from_coqui_chkpt(chkpt, verbose=False)
+        assert restored == iaft
+
+
+def test_from_coqui_chkpt_rejects_mismatched_grid():
+    """A checkpoint whose stored mesh disagrees with the grid rebuilt from its own
+    scalar metadata cannot be reinterpreted on that grid, so the load must fail loudly
+    instead of silently handing back an IAFT on the wrong nodes."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        chkpt = os.path.join(tmpdir, "iaft_bad_mesh.h5")
+        with HDFArchive(chkpt, 'w') as ar:
+            ar.create_group('imaginary_fourier_transform')
+            grp = ar['imaginary_fourier_transform']
+            grp['beta'] = 5.0
+            grp['wmax'] = 10.0
+            grp['prec'] = 'high'
+            grp['basis'] = 'dlr'
+            grp.create_group('tau_mesh')
+            grp['tau_mesh']['fermion'] = np.array([-1.0, 0.0, 1.0])
+            grp['tau_mesh']['boson'] = np.array([-1.0, 0.0, 1.0])
+
+        with pytest.raises(ValueError, match="tau_mesh"):
+            IAFT.from_coqui_chkpt(chkpt, verbose=False)
+
+
+def test_from_coqui_chkpt_without_meshes_still_loads():
+    """Old checkpoints that do not contain the meshes must still load."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        chkpt = os.path.join(tmpdir, "iaft_no_mesh.h5")
+        with HDFArchive(chkpt, 'w') as ar:
+            ar.create_group('imaginary_fourier_transform')
+            grp = ar['imaginary_fourier_transform']
+            grp['beta'] = 5.0
+            grp['wmax'] = 10.0
+            grp['prec'] = 'high'
+            grp['basis'] = 'dlr'
+
+        restored = IAFT.from_coqui_chkpt(chkpt, verbose=False)
+        assert restored.beta == pytest.approx(5.0)


### PR DESCRIPTION
Updates cppdlr to `7a0f60c`, which includes the symmetric-DLR grid fix in [cppdlr #20](https://github.com/flatironinstitute/cppdlr/pull/20) for the self-consistent GW/GF2 divergence reported in [cppdlr #19](https://github.com/flatironinstitute/cppdlr/issues/19). This pins upstream `main` as checked on 2026-09-09 rather than tracking the branch.

Note that as mentioned in the following comment by Chia-Nan: _this update changes how the DLR meshes are generated, so the rank and the node positions can differ from what an older build produced._

## Validation

The results below are from the previous pin, `6f3f2d8`, the newer commit only changed documents. Both focused tests, `test_iaft_dlr` and `test_iaft`, passed.

The before/after runs used cppdlr `f6bd6ab` and `6f3f2d8`, respectively. All material runs used symmetric DLR (per CoQui implementation) with `beta = 300 Ha^-1`, `Lambda = 10000`, precision `high` (`eps = 1e-13`), and fresh scGW starts (`restart = false`). The mesh sizes `(nt_f, nt_b, nw_f, nw_b)` changed from `(88, 88, 88, 89)` to `(89, 89, 90, 89)`.

| System | k mesh | Bands | GW divergence treatment | HF divergence treatment |
| --- | --- | --- | --- | --- |
| fcc Al | `5x5x5` | 200 | `gygi_order_1_metal` | `gygi` |
| cubic SrVO3 | `4x4x4` | 150 | `gygi_extrplt` | `gygi` |

`dFock` and `dSigma` are the printed maximum absolute changes in the Fock matrix and self-energy.

| Calculation | Before cppdlr #20 | After cppdlr #20 |
| --- | --- | --- |
| Al, DIIS with mixing `0.10` on both sides | Residuals grew after iteration 4, reaching `dFock = 1.00e-1`, `dSigma = 1.72e-1` at iteration 9 | Reached `dFock = 1.47e-7`, `dSigma = 5.46e-7` at iteration 9 |
| SrVO3, simple mixing `0.10` on both sides | Diverged: `dSigma = 1.14e3` at iteration 8 and `4.95e3` at iteration 9 | Remained stable through 24 iterations, ending at `dFock = 4.65e-4`, `dSigma = 2.84e-3`; not yet converged to `1e-6` |

More detailed trajectories are in the next section.

Al already used DIIS before the fix. The SrVO3 simple-mixing comparison reused the same MF and THC inputs and shows the improvement without DIIS. A separate post-fix SrVO3 run with commutator DIIS and mixing `0.60` reached both residuals below `1e-6` at iteration 11, then `dFock = 4.90e-8`, `dSigma = 6.85e-8` at iteration 12. Both post-fix DIIS runs used warmup 2 and maximum subspace 6.

- Without DIIS, a linear mixing SrVO3 run stayed stable along a smooth IR-like trajectory for 24 iterations, reaching `dFock = 4.65e-4` and `dSigma = 2.84e-3`.

These results support the cppdlr upstream fix for GW without an additional CoQui DLR workaround. SrVO3 and Al reached the `1e-6` threshold basically within the same iteration number of IR basis. Therefore, this fix should be considered as similar stability between IR and DLR symmetric mesh for CoQui.

### Iteration trajectories

<details>
<summary>Al: before/after cppdlr #20, DIIS with mixing 0.10 on both sides</summary>

Both runs used the same physical input and commutator DIIS settings: mixing `0.10`, warmup 2, maximum subspace 6. The old-DLR reproduction (job `26813207`) used CoQui `eaa0fd1` with memory fixes; the post-fix run (job `25459227`) used CoQui `a19774d`. The physical and DIIS settings match, but the CoQui builds differ.

| Iteration | Before `dFock` | Before `dSigma` | After `dFock` | After `dSigma` |
| ---: | ---: | ---: | ---: | ---: |
| 1 | `8.718425e-1` | `1.423786e+0` | `8.718425e-1` | `1.423786e+0` |
| 2 | `1.704643e-3` | `1.947725e-2` | `1.704645e-3` | `1.947726e-2` |
| 3 | `1.485368e-3` | `1.723152e-2` | `1.485398e-3` | `1.723172e-2` |
| 4 | `5.966454e-3` | `2.240425e-2` | `5.866956e-3` | `2.212082e-2` |
| 5 | `4.639542e-2` | `5.305666e-2` | `1.362304e-4` | `4.265719e-4` |
| 6 | `3.372828e-2` | `3.762693e-2` | `2.524615e-6` | `1.541437e-5` |
| 7 | `8.599397e-2` | `1.188182e-1` | `6.401432e-6` | `5.717835e-6` |
| 8 | `9.614780e-2` | `1.558420e-1` | `1.619772e-6` | `1.442523e-6` |
| 9 | `1.001749e-1` | `1.720964e-1` | `1.470427e-7` | `5.456304e-7` |

</details>

<details>
<summary>SrVO3: before/after cppdlr #20, simple mixing 0.10 on both sides</summary>

| Iteration | Before `dFock` | Before `dSigma` | After `dFock` | After `dSigma` |
| ---: | ---: | ---: | ---: | ---: |
| 1 | `6.225698e-1` | `9.386043e-1` | `6.225698e-1` | `9.386043e-1` |
| 2 | `1.453743e-2` | `4.918639e-2` | `1.453740e-2` | `4.918638e-2` |
| 3 | `1.197616e-2` | `4.350940e-2` | `1.197537e-2` | `4.350893e-2` |
| 4 | `9.942681e-3` | `3.845852e-2` | `9.917395e-3` | `3.844728e-2` |
| 5 | `9.000578e-3` | `3.429899e-2` | `8.255852e-3` | `3.394291e-2` |
| 6 | `2.594634e-2` | `4.046728e-2` | `6.906759e-3` | `2.994103e-2` |
| 7 | `1.266261e-1` | `4.714878e-1` | `5.804869e-3` | `2.639072e-2` |
| 8 | `3.207841e+0` | `1.143405e+3` | `4.899549e-3` | `2.324509e-2` |
| 9 | `1.341713e+2` | `4.953019e+3` | `4.151466e-3` | `2.046118e-2` |
| 10 | `1.333374e+1` | `5.093016e+2` | `3.529962e-3` | `1.799992e-2` |
| 11 | `1.180788e+1` | `2.601955e+3` | `3.011032e-3` | `1.582586e-2` |
| 12 | `1.147977e+1` | `2.548891e+3` | `2.575775e-3` | `1.390705e-2` |
| 13 | `1.025505e+1` | `2.303500e+3` | `2.209262e-3` | `1.221475e-2` |
| 14 | `9.123521e+0` | `9.238023e+2` | `1.899435e-3` | `1.072319e-2` |
| 15 | `4.504972e+1` | `5.142557e+3` | `1.636692e-3` | `9.409348e-3` |
| 16 | `8.429429e+0` | `4.867066e+2` | `1.413189e-3` | `8.252664e-3` |
| 17 | `7.599948e+0` | `4.380503e+2` | `1.222565e-3` | `7.234850e-3` |
| 18 | `6.778545e+0` | `3.979081e+2` | `1.059597e-3` | `6.339644e-3` |
| 19 | `5.965603e+0` | `3.545473e+2` | `9.199731e-4` | `5.552618e-3` |
| 20 | `5.346377e+0` | `3.182076e+2` | `8.001127e-4` | `4.860982e-3` |
| 21 | `4.730837e+0` | `2.876074e+2` | `6.970303e-4` | `4.253412e-3` |
| 22 | `4.121623e+0` | `2.584904e+2` | `6.082257e-4` | `3.719892e-3` |
| 23 | `3.662997e+0` | `2.316835e+2` | `5.315968e-4` | `3.251571e-3` |
| 24 | `3.099459e+0` | `2.117407e+2` | `4.653711e-4` | `2.840632e-3` |

</details>

<details>
<summary>SrVO3: after cppdlr #20, commutator DIIS with mixing 0.60</summary>

| Iteration | `dFock` | `dSigma` |
| ---: | ---: | ---: |
| 1 | `6.225698e-1` | `9.386043e-1` |
| 2 | `8.722441e-2` | `2.951183e-1` |
| 3 | `1.327954e-2` | `8.779872e-2` |
| 4 | `1.191017e-2` | `1.101413e-2` |
| 5 | `3.480496e-3` | `2.166836e-3` |
| 6 | `9.866051e-4` | `8.863148e-4` |
| 7 | `4.309476e-4` | `2.364123e-4` |
| 8 | `9.911688e-5` | `2.050020e-5` |
| 9 | `9.351121e-6` | `6.253971e-6` |
| 10 | `2.132669e-6` | `1.038750e-6` |
| 11 | `4.383454e-7` | `1.874568e-7` |
| 12 | `4.895350e-8` | `6.847961e-8` |

</details>

## Acknowledgement

[Xiansheng Cai](https://github.com/iintSjds) also suggested checking this bug and making the comparison.
