### PR TITLE
Fix the imaginary-axis window in dyson_scf_gw_diis_vs_damping so the test is portable across BLAS/LAPACK

### DIFF
--- a/src/methods/SCF/tests/test_scf_common.cpp
+++ b/src/methods/SCF/tests/test_scf_common.cpp
@@ -189,8 +189,11 @@ namespace bdft_tests {
   TEST_CASE("dyson_scf_gw_diis_vs_damping", "[methods_scf]") {
     auto& mpi_context = utils::make_unit_test_mpi_context();
 
-    // Cheap setup for regression: lower beta/wmax and compact THC factors.
-    imag_axes_ft::IAFT ft(200.0, 0.8, imag_axes_ft::dlr_basis);
+    // Cheap setup for regression: short beta and compact THC factors. wmax must
+    // cover the spectrum of H0+F relative to mu (max|eps-mu| = 2.11 a.u. here);
+    // a narrower window leaves G outside the DLR's representable range, and the
+    // converged energies then vary by ~1e-6 between BLAS/LAPACK implementations.
+    imag_axes_ft::IAFT ft(100.0, 2.4, imag_axes_ft::dlr_basis);
     auto mf = std::make_shared<mf::MF>(mf::default_MF(mpi_context, "qe_lih222"));
 
     auto run_dyson_gw = [&](iter_scf::iter_scf_t &iter_sol, const std::string &output)
@@ -205,7 +208,7 @@ namespace bdft_tests {
       MBState mb_state(mpi_context, ft, output);
       auto [e_hf, e_corr] = scf_loop(mb_state, dyson, eri, ft,
                                      solvers::mb_solver_t(&hf, &gw, &scr_eri), &iter_sol,
-                                     50, false, 1e-7, true);
+                                     50, false, 5e-8, true);
       mpi_context->comm.barrier();
       if (mpi_context->comm.root()) std::remove((output + ".mbpt.h5").c_str());
       mpi_context->comm.barrier();
@@ -219,8 +222,8 @@ namespace bdft_tests {
     auto [e_hf_diis, e_corr_diis] = run_dyson_gw(diis_sol, "dyson_gw_diis_test");
 
     // Damping reference for this cheap setup; DIIS should converge to the same state.
-    constexpr double e_hf_ref = -0.41698958999621144 + -3.7523191620415846;
-    constexpr double e_corr_ref = -0.10985159447702234;
+    constexpr double e_hf_ref = -0.4146530183717176 + -3.8314258924454028;
+    constexpr double e_corr_ref = -0.0887842498009347;
     constexpr double tol = 1e-6;
     VALUE_EQUAL(e_hf_damp, e_hf_ref, tol, tol);
     VALUE_EQUAL(e_corr_damp, e_corr_ref, tol, tol);


### PR DESCRIPTION
## Problem
`dyson_scf_gw_diis_vs_damping` (`src/methods/SCF/tests/test_scf_common.cpp`) failed on builds
using reference LAPACK, by ~4e-6 against a 1e-6 tolerance, with damping and DIIS internally
consistent to ~1e-9 (#53).

The test built its DLR grid with `wmax = 0.8` a.u., but the spectrum it has to represent is much
wider (fixture `qe_lih222`, converged `mu`):

| quantity | value |
|---|---|
| DLR window | ±0.8 a.u. around `mu` |
| stored DFT eigenvalues, max\|ε−mu\| | 1.88 (2.4× wmax) |
| `H0+F` eigenvalues, max\|ε−mu\| | **2.11** (2.6× wmax) |
| `H0+F` eigenvalues outside the window | **57.8%** (74 of 128) |

So `G` was not representable, the τ↔iω transform was accurate only to ~1e-8, and two LAPACK
implementations landed at different points inside that error bar. It is not an SCF instability:
with a bit-identical ERI the split is already present at iteration 0 — `F_skij` agrees to
6.7e-15 while `G_tskij` differs by 2.4e-8 — is multiplied ~80× by one GW step, then frozen flat
from iteration 6 to 21 by the contraction.

Round-trip error of the exact non-interacting `G` built from the fixture's own eigenvalues, at
`prec="medium"` (eps 1e-10):

| wmax | nt | covers spectrum | ‖round-trip − G‖/‖G‖ | MKL vs NETLIB on that G |
|---|---|---|---|---|
| 0.8 | 34 | no  | 3.3e-9  | 1.4e-8 |
| 1.6 | 40 | no  | 2.3e-12 | — |
| 2.2 | 44 | yes | 4.0e-15 | — |
| 2.4 | 44 | yes | 1.0e-15 | **1.1e-14** |

Note `IAFT::check_leakage`, the diagnostic for exactly this, is a documented no-op on the DLR
backend, so nothing warned.

## Fix
`src/methods/SCF/tests/test_scf_common.cpp`, `dyson_scf_gw_diis_vs_damping` only:

- `IAFT ft(200.0, 0.8, dlr_basis)` → `IAFT ft(100.0, 2.4, dlr_basis)`
- `scf_loop(..., 50, false, 1e-7, true)` → `5e-8`
- reference constants regenerated

`wmax = 2.4` covers the spectrum. **`beta = 100` is required, not cosmetic**: at `beta = 200` the
wider window makes damping at mixing 0.5 unstable — the Fock residual bottoms out at 1.38e-8 at
iteration 34 then grows at 1.068/iteration, while `|dSigma|` parks at ~6e-6 — and only mixing 0.4
converges, in 169 iterations. Since the test asserts DIIS *against* damping, the damping arm must
converge on its own. Halving beta removes the stiff mode and also halves `lambda = beta*wmax`, so
the grid stays small (nt 34 → 38).

Mixing (0.5), `niter` (50) and `tol` (1e-6) are unchanged.

## Test
`mpiexec -n 4 build/tests/bin/test_methods_scf dyson_scf_gw_diis_vs_damping`, run twice — once
normally (MKL) and once with reference LAPACK interposed via
`LD_PRELOAD=libflexiblas.so FLEXIBLAS=NETLIB`, which reproduces #53 on this machine.

Deviation from the committed reference:

| arm | iters | before, MKL | before, NETLIB | after, MKL | after, NETLIB |
|---|---|---|---|---|---|
| damping `e_hf`   | 40 | −2.7e-15 | **+4.67e-6 FAIL** | +8.9e-16 | +5.2e-9 |
| damping `e_corr` | 40 | +2.6e-16 | **−2.50e-6 FAIL** | −4.2e-17 | +2.0e-9 |
| diis `e_hf`      | 11 | +2.3e-9  | **+4.67e-6 FAIL** | +3.2e-9  | +8.0e-9 |
| diis `e_corr`    | 11 | +5.1e-10 | **−2.50e-6 FAIL** | −4.5e-10 | +1.8e-9 |

Every deviation is now ≥125× inside the 1e-6 tolerance, against a reference implementation that
previously failed it by 2–4×. Both arms converge (damping 40 iterations, DIIS 11, cap 50).

Full suite green: `mpiexec -n 8 build/tests/bin/test_methods_scf` → *All tests passed (215196
assertions in 8 test cases)*.

The reporter's ~3.8e-6 and the NETLIB ~4.7e-6 differ because FlexiBLAS's NETLIB build is not their
LAPACK 3.11; the failure mode and sign match. Only two LAPACK implementations have been sampled,
so `tol` is deliberately left at 1e-6 rather than tightened.
