### PR TITLE
fix: reuse existing c2py target in Python builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -375,6 +375,35 @@ if(ENABLE_SPDLOG)
 endif()
 
 ######################################################################
+# Python, c2py and clair for pybinding
+#
+# Fetched before nda and the other dependencies so that they all reuse this
+# single, self-consistent c2py target instead of resolving one of their own.
+######################################################################
+if(COQUI_PYTHON_SUPPORT)
+  find_package(Python COMPONENTS Interpreter Development NumPy)
+
+  if(DEFINED C2PY)
+    set(FETCHCONTENT_SOURCE_DIR_C2PY ${C2PY})
+  endif()
+  FetchContent_Declare(
+    c2py
+    GIT_REPOSITORY https://github.com/flatironinstitute/c2py
+    GIT_TAG        unstable
+    EXCLUDE_FROM_ALL
+  )
+  if(NOT TARGET c2py)
+    FetchContent_MakeAvailable(c2py)
+  else()
+    message(STATUS "Reusing c2py target already provided by other dependency")
+  endif()
+
+  if (COQUI_UPDATE_PYTHON_BINDINGS)
+    find_program(clair-c2py clair-c2py REQUIRED)
+  endif()
+endif()
+
+######################################################################
 # nda: a C++ library providing multi-dimensional array classes
 ######################################################################
 if(DEFINED NDA) 
@@ -484,29 +513,6 @@ if(ENABLE_CPPTRACE)
   )
   FetchContent_MakeAvailable(cpptrace)
 endif(ENABLE_CPPTRACE)
-
-########################
-# Find Python, c2py and clair for pybinding
-########################
-if(COQUI_PYTHON_SUPPORT)
-  find_package(Python COMPONENTS Interpreter Development NumPy)
-  # Fetch the c2py library
-  FetchContent_Declare(
-    c2py
-    GIT_REPOSITORY https://github.com/flatironinstitute/c2py
-    GIT_TAG        unstable
-    EXCLUDE_FROM_ALL
-  )
-  # NDA's h5 dependency may already provide c2py when Python support is enabled.
-  # Reuse that target instead of adding the same FetchContent project twice.
-  if(NOT TARGET c2py::c2py)
-    FetchContent_MakeAvailable(c2py)
-  endif()
-
-  if (COQUI_UPDATE_PYTHON_BINDINGS)
-    find_program(clair-c2py clair-c2py REQUIRED)
-  endif()
-endif()
 
 ######################################################################
 # lab-cosmo sphericart 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -497,7 +497,11 @@ if(COQUI_PYTHON_SUPPORT)
     GIT_TAG        unstable
     EXCLUDE_FROM_ALL
   )
-  FetchContent_MakeAvailable(c2py)
+  # NDA's h5 dependency may already provide c2py when Python support is enabled.
+  # Reuse that target instead of adding the same FetchContent project twice.
+  if(NOT TARGET c2py::c2py)
+    FetchContent_MakeAvailable(c2py)
+  endif()
 
   if (COQUI_UPDATE_PYTHON_BINDINGS)
     find_program(clair-c2py clair-c2py REQUIRED)


### PR DESCRIPTION
## Summary

Split the independent CMake fix out of #51 so it can be reviewed and merged separately from the cppdlr dependency update.

- When Python support is enabled, NDA/h5 may already provide `c2py::c2py`.
- Call `FetchContent_MakeAvailable(c2py)` only when that target does not exist, avoiding duplicate c2py target creation.
- No cppdlr dependency changes are included.

Fixes #52.

## Validation

- `git diff --cached --check` passed.
- This is the same guard previously included in #51. No new full configure/build or reproduction of the issue reporter’s environment was run for this split.